### PR TITLE
ci: add python-tests matrix, dashboard build/lint, and critical-branch gate

### DIFF
--- a/.github/workflows/security-and-audit.yml
+++ b/.github/workflows/security-and-audit.yml
@@ -44,6 +44,83 @@ jobs:
       - name: Run npm audit (high+)
         run: npm audit --audit-level=high
 
+  python-tests:
+    name: Python tests (${{ matrix.suite }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        suite: [unit, integration]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: pip
+          cache-dependency-path: requirements.txt
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run pytest - unit
+        if: matrix.suite == 'unit'
+        run: |
+          pytest -q -m "not integration" --junitxml=pytest-unit.xml
+      - name: Run pytest - integration
+        if: matrix.suite == 'integration'
+        run: |
+          pytest -q -m "integration" --junitxml=pytest-integration.xml
+      - name: Upload pytest artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pytest-${{ matrix.suite }}-artifacts
+          path: |
+            pytest-*.xml
+            .pytest_cache
+          if-no-files-found: ignore
+
+  dashboard-build-lint:
+    name: Dashboard build and lint
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: dashboard
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: dashboard/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+      - name: Lint
+        run: npm run lint
+      - name: Build
+        run: npm run build
+      - name: Upload dashboard artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dashboard-build-artifacts
+          path: |
+            dashboard/dist
+            dashboard/npm-debug.log*
+            dashboard/.npm/_logs
+          if-no-files-found: ignore
+
+  required-critical-gates:
+    name: Required CI gates (critical branches)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && (github.base_ref == 'main' || github.base_ref == 'master' || github.base_ref == 'work')
+    needs:
+      - python-tests
+      - dashboard-build-lint
+    steps:
+      - name: Confirm required gates passed
+        run: echo "All required CI gates passed for critical branch PR."
+
   leaked-secret-promotion-guard:
     name: Unsafe promotion guard
     runs-on: ubuntu-latest

--- a/docs/CI_REQUIRED_CHECKS.md
+++ b/docs/CI_REQUIRED_CHECKS.md
@@ -1,0 +1,19 @@
+# CI checks required before merge (critical branches)
+
+For pull requests targeting critical branches (`main`, `master`, `work`), require the following status check in GitHub branch protection:
+
+- `Required CI gates (critical branches)`
+
+This gate depends on:
+
+- `Python tests (unit)` and `Python tests (integration)` from the `python-tests` matrix job.
+- `Dashboard build and lint`.
+
+Recommended GitHub configuration:
+
+1. Go to **Settings → Branches**.
+2. Add (or edit) protection rules for `main`, `master`, `work`.
+3. Enable **Require status checks to pass before merging**.
+4. Mark `Required CI gates (critical branches)` as required.
+
+Artifacts are published for diagnostics even when jobs fail.

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,5 +2,6 @@
 asyncio_mode = auto
 asyncio_default_fixture_loop_scope = function
 markers =
+    unit: marks fast unit tests
     integration: marks integration tests
     asyncio: marks asyncio tests


### PR DESCRIPTION
### Motivation
- Keep CI fast by separating unit and integration test suites and running them in a matrix so quick checks run independently from slower integration tests.
- Provide better post-failure diagnostics by publishing test and build artifacts even when jobs fail.
- Enforce a single required gate for PRs targeting critical branches so branch protection can block merges unless quality gates pass.

### Description
- Added a new GitHub Actions job `python-tests` with a `matrix: [unit, integration]` that installs `requirements.txt`, runs `pytest -q` with marker filters (`-m "not integration"` / `-m "integration"`), and uploads `junitxml` and `.pytest_cache` artifacts using `actions/upload-artifact@v4`.
- Added a `dashboard-build-lint` job (working-directory `dashboard`) that runs `npm ci`, `npm run lint`, `npm run build`, and uploads build/log artifacts for diagnostics.
- Added a `required-critical-gates` aggregator job that runs only for PRs targeting `main`, `master`, or `work` and depends on `python-tests` and `dashboard-build-lint` so it can be selected as the single required status check in branch protection.
- Documented the branch-protection recommendation in `docs/CI_REQUIRED_CHECKS.md` and added a `unit` pytest marker to `pytest.ini` to explicitely separate unit vs integration tests.

### Testing
- Ran local collection with `pytest --collect-only -q -m "not integration"`, which failed during collection due to a missing dependency (`httpx` required by `starlette.testclient`) in the local environment.
- CI workflow is configured to upload artifacts with `if: always()` so build/test outputs are retained for post-failure diagnostics (artifact upload not validated here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e80f1b3608832fb190b5df1f279de4)