### PR TITLE
refactor(v2): extract orchestrator services and add focused tests

### DIFF
--- a/src/autobot/v2/orchestrator_async.py
+++ b/src/autobot/v2/orchestrator_async.py
@@ -120,20 +120,29 @@ from .risk_manager import OrchestratorRiskManager
 from .universe_manager import UniverseManager
 from .pair_ranking_engine import PairRankingEngine
 from .scalability_guard import (
-    GuardInput,
     GuardThresholds,
     ScalabilityGuard,
     ScalingState,
 )
 from .global_kill_switch import GlobalKillSwitchStore
 from .instance_activation_manager import (
-    ActivationInput,
     InstanceActivationManager,
 )
 from .portfolio_allocator import (
     AllocationConstraints,
     AllocationPlan,
     PortfolioAllocator,
+)
+from .orchestrator_services import (
+    ActivationContext,
+    BackgroundTasksService,
+    DecisionJournalService,
+    InstanceActivationService,
+    InstanceLifecycleService,
+    PortfolioAllocationService,
+    ScalabilityGuardService,
+    ScalabilityMetrics,
+    journal_symbol_cap,
 )
 from .decision_journal import (
     DecisionJournal,
@@ -485,6 +494,18 @@ class OrchestratorAsync:
                     risk_per_capital_ratio=PORTFOLIO_RISK_PER_CAPITAL_RATIO,
                 )
             )
+        self.lifecycle_service = InstanceLifecycleService()
+        self.background_tasks = BackgroundTasksService()
+        self.decision_journal_service = DecisionJournalService(
+            journal=self.decision_journal,
+            enabled=self._decision_journal_enabled,
+        )
+        self.scalability_guard_service = ScalabilityGuardService(self.scalability_guard)
+        self.instance_activation_service = InstanceActivationService(self.instance_activation_manager)
+        self.portfolio_allocation_service = PortfolioAllocationService(
+            self.portfolio_allocator,
+            self.risk_cluster_manager,
+        )
 
         # Market selector (reuse sync version)
         try:
@@ -1027,8 +1048,8 @@ class OrchestratorAsync:
             fails = sum(1 for v in self._last_validation_guard.values() if not bool(v.get("passed", True)))
             validation_degraded = (fails / max(1, len(self._last_validation_guard))) > SCALING_GUARD_VALIDATION_FAIL_MAX
 
-        decision = self.scalability_guard.evaluate(
-            GuardInput(
+        decision = self.scalability_guard_service.evaluate(
+            ScalabilityMetrics(
                 cpu_pct=cpu_pct,
                 memory_pct=memory_pct,
                 ws_connected=ws_connected,
@@ -1041,6 +1062,8 @@ class OrchestratorAsync:
                 validation_degraded=validation_degraded,
             )
         )
+        if decision is None:
+            return
         self.scalability_guard_state = decision.state
         self._scalability_guard_last = {
             "state": decision.state.value,
@@ -1091,21 +1114,20 @@ class OrchestratorAsync:
             if sym in scored_map
         ]
         avg_rank_score = (sum(score_values) / len(score_values)) if score_values else 0.0
-        below_threshold_symbols = [
-            sym
-            for sym in ranked_symbols
-            if sym in scored_map and float(scored_map.get(sym, {}).get("score", 0.0)) < float(RANKING_MIN_SCORE_ACTIVATE)
-        ]
+        below_threshold_symbols = self.instance_activation_service.below_threshold_symbols(
+            ranked_symbols,
+            scored_map,
+        )
         if below_threshold_symbols:
             low_fp = self._fingerprint(
                 {
-                    "symbols": below_threshold_symbols[: max(1, int(DECISION_JOURNAL_MAX_SYMBOLS))],
+                    "symbols": below_threshold_symbols[: journal_symbol_cap()],
                     "threshold": float(RANKING_MIN_SCORE_ACTIVATE),
                 }
             )
             if low_fp != self._journal_last_rejected_ranking_fp:
                 self._journal_last_rejected_ranking_fp = low_fp
-                for sym in below_threshold_symbols[: max(1, int(DECISION_JOURNAL_MAX_SYMBOLS))]:
+                for sym in below_threshold_symbols[: journal_symbol_cap()]:
                     self._journal_rejected_opportunity(
                         reason=REJECTION_REASON_RANKING_BELOW_THRESHOLD,
                         source="instance_activation_policy",
@@ -1116,69 +1138,67 @@ class OrchestratorAsync:
                         },
                     )
 
-        decision = self.instance_activation_manager.decide(
-            ActivationInput(
+        activation_result = self.instance_activation_service.apply(
+            ActivationContext(
                 ranked_symbols=ranked_symbols,
-                avg_rank_score=avg_rank_score,
+                scored_map=scored_map,
                 guard_state=self.scalability_guard_state,
                 health_score=self._compute_health_score(),
                 running_instances=len([i for i in self._instances.values() if i.is_running()]),
                 now_ts=perf_counter(),
             )
         )
-        self._activation_target_instances = max(1, int(decision.target_instances))
+        if activation_result is None:
+            return
+        decision = activation_result.payload
+        self._activation_target_instances = int(activation_result.target_instances)
         self._activation_last = {
-            "action": decision.action,
+            "action": decision["action"],
             "target_instances": self._activation_target_instances,
-            "target_tier": int(decision.target_tier),
-            "selected_symbols": list(decision.selected_symbols),
-            "reason": decision.reason,
+            "target_tier": int(decision["target_tier"]),
+            "selected_symbols": list(decision["selected_symbols"]),
+            "reason": decision["reason"],
         }
-        if decision.action in {"promote", "demote", "freeze"}:
+        if decision["action"] in {"promote", "demote", "freeze"}:
             self._journal_major_decision(
                 decision_type="activation_decision",
                 source="instance_activation_manager",
-                symbols=list(decision.selected_symbols[: max(1, int(DECISION_JOURNAL_MAX_SYMBOLS))]),
-                reasons=[decision.reason],
+                symbols=list(decision["selected_symbols"][: journal_symbol_cap()]),
+                reasons=[decision["reason"]],
                 context={
-                    "action": decision.action,
+                    "action": decision["action"],
                     "target_instances": int(self._activation_target_instances),
-                    "target_tier": int(decision.target_tier),
+                    "target_tier": int(decision["target_tier"]),
                     "avg_rank_score": float(avg_rank_score),
                     "guard_state": self.scalability_guard_state.value,
                     "running_instances": len([i for i in self._instances.values() if i.is_running()]),
                 },
             )
-        if decision.action in {"promote", "demote", "freeze"}:
-            selected_set = set(str(s) for s in decision.selected_symbols)
-            not_selected = [
-                sym for sym in ranked_symbols
-                if str(sym) not in selected_set
-            ]
-            for sym in not_selected[: max(0, int(DECISION_JOURNAL_MAX_SYMBOLS) - len(decision.selected_symbols))]:
+        if decision["action"] in {"promote", "demote", "freeze"}:
+            for sym in activation_result.rejected_symbols[: max(0, journal_symbol_cap() - len(decision["selected_symbols"]))]:
                 self._journal_rejected_opportunity(
                     reason=REJECTION_REASON_SYMBOL_NOT_SELECTED,
                     source="instance_activation_policy",
                     symbol=str(sym),
                     context={
-                        "action": decision.action,
-                        "target_tier": int(decision.target_tier),
+                        "action": decision["action"],
+                        "target_tier": int(decision["target_tier"]),
                     },
                 )
 
         # Demote path: reduce non-parent instances to target cap (conservative).
-        running = [inst for inst in self._instances.values() if inst.is_running() and inst.id != self.parent_instance_id]
+        running = [
+            inst for inst in self.lifecycle_service.running_instances(self._instances.values())
+            if inst.id != self.parent_instance_id
+        ]
         excess = max(0, len(self._instances) - self._activation_target_instances)
         if excess > 0:
-            victims = sorted(
-                running,
-                key=lambda inst: float(getattr(inst, "get_profit_factor_days", lambda _d: 1.0)(30)),
-            )[:excess]
+            victims = self.lifecycle_service.select_worst_by_pf(running, excess)
             for victim in victims:
                 await self.remove_instance(victim.id)
 
     def _refresh_portfolio_allocation_plan(self) -> None:
-        if self.portfolio_allocator is None:
+        if self.portfolio_allocation_service.allocator is None:
             self._portfolio_plan = None
             return
 
@@ -1191,36 +1211,13 @@ class OrchestratorAsync:
         if not ranked_symbols:
             ranked_symbols = sorted({inst.config.symbol for inst in active_instances})
 
-        symbol_exposure: Dict[str, float] = {}
-        for inst in active_instances:
-            symbol = str(inst.config.symbol)
-            symbol_exposure[symbol] = symbol_exposure.get(symbol, 0.0) + max(0.0, float(inst.get_current_capital()))
-
-        cluster_exposure = self.risk_cluster_manager.exposure_by_cluster(active_instances)
-        total_capital = sum(max(0.0, float(inst.get_current_capital())) for inst in active_instances)
-        if total_capital <= 0.0:
-            total_capital = sum(max(0.0, float(inst.get_current_capital())) for inst in self._instances.values())
-
-        # Lightweight active-risk proxy based on current exposures.
-        current_active_risk = 0.0
-        if self.portfolio_allocator is not None:
-            current_active_risk = total_capital * self.portfolio_allocator.constraints.risk_per_capital_ratio
-
-        symbol_to_cluster = {
-            sym: self.risk_cluster_manager.cluster_for_symbol(sym)
-            for sym in ranked_symbols
-        }
-
-        self._portfolio_plan = self.portfolio_allocator.build_plan(
-            ranked_candidates=ranked_symbols,
-            total_capital=total_capital,
-            current_symbol_exposure=symbol_exposure,
-            current_cluster_exposure=dict(cluster_exposure),
-            current_active_risk=current_active_risk,
-            symbol_to_cluster=symbol_to_cluster,
+        self._portfolio_plan = self.portfolio_allocation_service.refresh_plan(
+            instances=active_instances,
+            fallback_instances=self._instances.values(),
+            ranked_symbols=ranked_symbols,
         )
         if self._portfolio_plan is not None:
-            top_symbols = list(self._portfolio_plan.symbol_caps.keys())[: max(1, int(DECISION_JOURNAL_MAX_SYMBOLS))]
+            top_symbols = list(self._portfolio_plan.symbol_caps.keys())[: journal_symbol_cap()]
             fp = self._fingerprint(
                 {
                     "symbol_caps": {k: round(float(v), 2) for k, v in self._portfolio_plan.symbol_caps.items()},
@@ -1241,7 +1238,7 @@ class OrchestratorAsync:
                         "risk_budget_remaining": float(self._portfolio_plan.risk_budget_remaining),
                         "symbol_caps": {
                             k: float(v)
-                            for k, v in list(self._portfolio_plan.symbol_caps.items())[: int(DECISION_JOURNAL_MAX_SYMBOLS)]
+                            for k, v in list(self._portfolio_plan.symbol_caps.items())[: journal_symbol_cap()]
                         },
                     },
                 )
@@ -1254,10 +1251,10 @@ class OrchestratorAsync:
         ]
         if not removable:
             return
-        worst = min(
-            removable,
-            key=lambda inst: float(getattr(inst, "get_profit_factor_days", lambda _d: 1.0)(30)),
-        )
+        worst_candidates = self.lifecycle_service.select_worst_by_pf(removable, 1)
+        if not worst_candidates:
+            return
+        worst = worst_candidates[0]
         self._journal_major_decision(
             decision_type="guard_force_reduce",
             source="scalability_guard",
@@ -1432,15 +1429,12 @@ class OrchestratorAsync:
         reasons: Optional[List[str]] = None,
         context: Optional[Dict[str, Any]] = None,
     ) -> None:
-        if not self._decision_journal_enabled:
-            return
-        self.decision_journal.log(
+        self.decision_journal_service.major_decision(
             decision_type=decision_type,
             source=source,
             symbols=symbols or [],
             reasons=reasons or [],
             context=context or {},
-            session_id=os.getenv("DECISION_JOURNAL_SESSION_ID", "").strip() or None,
         )
 
     def _journal_rejected_opportunity(
@@ -1461,11 +1455,7 @@ class OrchestratorAsync:
         )
 
     def _fingerprint(self, payload: Any) -> str:
-        try:
-            import json
-            return json.dumps(payload, sort_keys=True, ensure_ascii=False, default=str)
-        except Exception:
-            return repr(payload)
+        return self.decision_journal_service.fingerprint(payload)
 
     def _set_last_decision(self, instance_id: str, action: str, reason: str) -> None:
         priority = self.decision_policy.get(action, 0)
@@ -2464,10 +2454,18 @@ class OrchestratorAsync:
 
         # Start optional modules (DailyReporter, RebalanceManager, etc.)
         await self.module_manager.start()
-        self._daily_report_task = asyncio.create_task(self._daily_report_loop())
-        self._xgboost_train_task = asyncio.create_task(self._train_xgboost_loop())
-        self._sentiment_task = asyncio.create_task(self._sentiment_update_loop())
-        self._cycle_health_task = asyncio.create_task(self._check_cycle_health())
+        self.background_tasks.start(
+            {
+                "daily_report": self._daily_report_loop,
+                "xgboost_train": self._train_xgboost_loop,
+                "sentiment_update": self._sentiment_update_loop,
+                "cycle_health": self._check_cycle_health,
+            }
+        )
+        self._daily_report_task = self.background_tasks.tasks.get("daily_report")
+        self._xgboost_train_task = self.background_tasks.tasks.get("xgboost_train")
+        self._sentiment_task = self.background_tasks.tasks.get("sentiment_update")
+        self._cycle_health_task = self.background_tasks.tasks.get("cycle_health")
         if self.paper_mode:
             total_capital = sum(
                 float(inst.get_current_capital()) for inst in self._instances.values()
@@ -2477,9 +2475,16 @@ class OrchestratorAsync:
                     "🕶️ Capital total paper+shadow %.2f€ > 1000€ (limite demandée)",
                     total_capital,
                 )
-            self._shadow_promotion_task = asyncio.create_task(self._check_shadow_promotions())
-            self._rebalance_task = asyncio.create_task(self._rebalance_loop())
-            self._auto_evolution_task = asyncio.create_task(self._auto_evolution_loop())
+            self.background_tasks.start(
+                {
+                    "shadow_promotion": self._check_shadow_promotions,
+                    "rebalance": self._rebalance_loop,
+                    "auto_evolution": self._auto_evolution_loop,
+                }
+            )
+            self._shadow_promotion_task = self.background_tasks.tasks.get("shadow_promotion")
+            self._rebalance_task = self.background_tasks.tasks.get("rebalance")
+            self._auto_evolution_task = self.background_tasks.tasks.get("auto_evolution")
             logger.info("🧪 Advanced modules activés en PAPER_TRADING=true")
         else:
             logger.warning("🧪 Advanced modules désactivés (PAPER_TRADING=false)")
@@ -2529,55 +2534,14 @@ class OrchestratorAsync:
                 await self._main_task
             except asyncio.CancelledError:
                 pass
-        if self._daily_report_task:
-            self._daily_report_task.cancel()
-            try:
-                await self._daily_report_task
-            except asyncio.CancelledError:
-                pass
-            self._daily_report_task = None
-        if self._xgboost_train_task:
-            self._xgboost_train_task.cancel()
-            try:
-                await self._xgboost_train_task
-            except asyncio.CancelledError:
-                pass
-            self._xgboost_train_task = None
-        if self._sentiment_task:
-            self._sentiment_task.cancel()
-            try:
-                await self._sentiment_task
-            except asyncio.CancelledError:
-                pass
-            self._sentiment_task = None
-        if self._cycle_health_task:
-            self._cycle_health_task.cancel()
-            try:
-                await self._cycle_health_task
-            except asyncio.CancelledError:
-                pass
-            self._cycle_health_task = None
-        if self._shadow_promotion_task:
-            self._shadow_promotion_task.cancel()
-            try:
-                await self._shadow_promotion_task
-            except asyncio.CancelledError:
-                pass
-            self._shadow_promotion_task = None
-        if self._rebalance_task:
-            self._rebalance_task.cancel()
-            try:
-                await self._rebalance_task
-            except asyncio.CancelledError:
-                pass
-            self._rebalance_task = None
-        if self._auto_evolution_task:
-            self._auto_evolution_task.cancel()
-            try:
-                await self._auto_evolution_task
-            except asyncio.CancelledError:
-                pass
-            self._auto_evolution_task = None
+        await self.background_tasks.stop()
+        self._daily_report_task = None
+        self._xgboost_train_task = None
+        self._sentiment_task = None
+        self._cycle_health_task = None
+        self._shadow_promotion_task = None
+        self._rebalance_task = None
+        self._auto_evolution_task = None
 
         for inst in list(self._instances.values()):
             await inst.stop()  # Each instance drains its queue + cancels consumer task

--- a/src/autobot/v2/orchestrator_services.py
+++ b/src/autobot/v2/orchestrator_services.py
@@ -1,0 +1,273 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, Dict, Iterable, List, Optional, Protocol, Sequence
+
+from .config import DECISION_JOURNAL_MAX_SYMBOLS, RANKING_MIN_SCORE_ACTIVATE
+from .instance_activation_manager import ActivationInput, InstanceActivationManager
+from .portfolio_allocator import AllocationPlan, PortfolioAllocator
+from .risk_cluster_manager import RiskClusterManager
+from .scalability_guard import GuardInput, ScalabilityGuard, ScalingState
+
+
+class JournalLike(Protocol):
+    def log(
+        self,
+        *,
+        decision_type: str,
+        source: str,
+        symbols: List[str],
+        reasons: List[str],
+        context: Dict[str, Any],
+        session_id: Optional[str] = None,
+    ) -> None:
+        ...
+
+
+class InstanceLike(Protocol):
+    id: str
+    config: Any
+
+    def is_running(self) -> bool:
+        ...
+
+    def get_profit_factor_days(self, days: int) -> float:
+        ...
+
+    def get_current_capital(self) -> float:
+        ...
+
+
+@dataclass
+class ScalabilityMetrics:
+    cpu_pct: float
+    memory_pct: float
+    ws_connected: bool
+    ws_stale_seconds: float
+    ws_total_lag: int
+    execution_failure_rate: float
+    reconciliation_mismatch_ratio: float
+    kill_switch_tripped: bool
+    pf_degraded: bool
+    validation_degraded: bool
+
+
+@dataclass
+class ActivationContext:
+    ranked_symbols: List[str]
+    scored_map: Dict[str, Dict[str, Any]]
+    guard_state: ScalingState
+    health_score: float
+    running_instances: int
+    now_ts: float
+
+
+@dataclass
+class ActivationResult:
+    target_instances: int
+    payload: Dict[str, Any]
+    rejected_symbols: List[str]
+
+
+class DecisionJournalService:
+    def __init__(self, journal: JournalLike, enabled: bool) -> None:
+        self.journal = journal
+        self.enabled = enabled
+
+    @staticmethod
+    def fingerprint(payload: Any) -> str:
+        try:
+            return json.dumps(payload, sort_keys=True, ensure_ascii=False, default=str)
+        except Exception:
+            return repr(payload)
+
+    def major_decision(
+        self,
+        *,
+        decision_type: str,
+        source: str,
+        symbols: Optional[List[str]] = None,
+        reasons: Optional[List[str]] = None,
+        context: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        if not self.enabled:
+            return
+        self.journal.log(
+            decision_type=decision_type,
+            source=source,
+            symbols=symbols or [],
+            reasons=reasons or [],
+            context=context or {},
+            session_id=os.getenv("DECISION_JOURNAL_SESSION_ID", "").strip() or None,
+        )
+
+    def rejected_opportunity(
+        self,
+        *,
+        reason: str,
+        source: str,
+        symbol: Optional[str] = None,
+        context: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        symbols = [str(symbol)] if symbol else []
+        self.major_decision(
+            decision_type="rejected_opportunity",
+            source=source,
+            symbols=symbols,
+            reasons=[reason],
+            context=context or {},
+        )
+
+
+class ScalabilityGuardService:
+    def __init__(self, guard: Optional[ScalabilityGuard]) -> None:
+        self.guard = guard
+
+    def evaluate(self, metrics: ScalabilityMetrics):
+        if self.guard is None:
+            return None
+        return self.guard.evaluate(
+            GuardInput(
+                cpu_pct=metrics.cpu_pct,
+                memory_pct=metrics.memory_pct,
+                ws_connected=metrics.ws_connected,
+                ws_stale_seconds=metrics.ws_stale_seconds,
+                ws_total_lag=metrics.ws_total_lag,
+                execution_failure_rate=metrics.execution_failure_rate,
+                reconciliation_mismatch_ratio=metrics.reconciliation_mismatch_ratio,
+                kill_switch_tripped=metrics.kill_switch_tripped,
+                pf_degraded=metrics.pf_degraded,
+                validation_degraded=metrics.validation_degraded,
+            )
+        )
+
+
+class InstanceActivationService:
+    def __init__(self, manager: Optional[InstanceActivationManager]) -> None:
+        self.manager = manager
+
+    def apply(self, context: ActivationContext) -> Optional[ActivationResult]:
+        if self.manager is None:
+            return None
+        decision = self.manager.decide(
+            ActivationInput(
+                ranked_symbols=context.ranked_symbols,
+                avg_rank_score=self._avg_score(context.ranked_symbols, context.scored_map),
+                guard_state=context.guard_state,
+                health_score=context.health_score,
+                running_instances=context.running_instances,
+                now_ts=context.now_ts,
+            )
+        )
+        selected_set = {str(s) for s in decision.selected_symbols}
+        rejected = [sym for sym in context.ranked_symbols if str(sym) not in selected_set]
+        return ActivationResult(
+            target_instances=max(1, int(decision.target_instances)),
+            payload={
+                "action": decision.action,
+                "target_tier": int(decision.target_tier),
+                "selected_symbols": list(decision.selected_symbols),
+                "reason": decision.reason,
+                "avg_rank_score": self._avg_score(context.ranked_symbols, context.scored_map),
+            },
+            rejected_symbols=rejected,
+        )
+
+    @staticmethod
+    def _avg_score(ranked_symbols: Sequence[str], scored_map: Dict[str, Dict[str, Any]]) -> float:
+        values = [
+            float(scored_map.get(sym, {}).get("score", 0.0))
+            for sym in ranked_symbols
+            if sym in scored_map
+        ]
+        return (sum(values) / len(values)) if values else 0.0
+
+    @staticmethod
+    def below_threshold_symbols(ranked_symbols: Sequence[str], scored_map: Dict[str, Dict[str, Any]]) -> List[str]:
+        return [
+            sym
+            for sym in ranked_symbols
+            if sym in scored_map and float(scored_map.get(sym, {}).get("score", 0.0)) < float(RANKING_MIN_SCORE_ACTIVATE)
+        ]
+
+
+class PortfolioAllocationService:
+    def __init__(self, allocator: Optional[PortfolioAllocator], cluster_manager: RiskClusterManager) -> None:
+        self.allocator = allocator
+        self.cluster_manager = cluster_manager
+
+    def refresh_plan(
+        self,
+        *,
+        instances: Iterable[InstanceLike],
+        fallback_instances: Iterable[InstanceLike],
+        ranked_symbols: List[str],
+    ) -> Optional[AllocationPlan]:
+        if self.allocator is None:
+            return None
+
+        active_instances = [inst for inst in instances if inst.is_running()]
+        symbol_exposure: Dict[str, float] = {}
+        for inst in active_instances:
+            symbol = str(inst.config.symbol)
+            symbol_exposure[symbol] = symbol_exposure.get(symbol, 0.0) + max(0.0, float(inst.get_current_capital()))
+
+        cluster_exposure = self.cluster_manager.exposure_by_cluster(active_instances)
+        total_capital = sum(max(0.0, float(inst.get_current_capital())) for inst in active_instances)
+        if total_capital <= 0.0:
+            total_capital = sum(max(0.0, float(inst.get_current_capital())) for inst in fallback_instances)
+
+        current_active_risk = total_capital * self.allocator.constraints.risk_per_capital_ratio
+        symbol_to_cluster = {sym: self.cluster_manager.cluster_for_symbol(sym) for sym in ranked_symbols}
+        return self.allocator.build_plan(
+            ranked_candidates=ranked_symbols,
+            total_capital=total_capital,
+            current_symbol_exposure=symbol_exposure,
+            current_cluster_exposure=dict(cluster_exposure),
+            current_active_risk=current_active_risk,
+            symbol_to_cluster=symbol_to_cluster,
+        )
+
+
+class InstanceLifecycleService:
+    @staticmethod
+    def running_instances(instances: Iterable[InstanceLike]) -> List[InstanceLike]:
+        return [inst for inst in instances if inst.is_running()]
+
+    @staticmethod
+    def select_worst_by_pf(instances: Iterable[InstanceLike], limit: int) -> List[InstanceLike]:
+        return sorted(
+            list(instances),
+            key=lambda inst: float(getattr(inst, "get_profit_factor_days", lambda _d: 1.0)(30)),
+        )[: max(0, int(limit))]
+
+
+class BackgroundTasksService:
+    def __init__(self) -> None:
+        self.tasks: Dict[str, asyncio.Task] = {}
+
+    def start(self, factories: Dict[str, Callable[[], Awaitable[Any]]]) -> None:
+        for name, factory in factories.items():
+            if name in self.tasks and not self.tasks[name].done():
+                continue
+            self.tasks[name] = asyncio.create_task(factory())
+
+    async def stop(self, names: Optional[Iterable[str]] = None) -> None:
+        targets = list(names) if names is not None else list(self.tasks.keys())
+        for name in targets:
+            task = self.tasks.get(name)
+            if task is None:
+                continue
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+            self.tasks.pop(name, None)
+
+
+def journal_symbol_cap() -> int:
+    return max(1, int(DECISION_JOURNAL_MAX_SYMBOLS))

--- a/tests/test_orchestrator_async_wiring.py
+++ b/tests/test_orchestrator_async_wiring.py
@@ -1,0 +1,33 @@
+from autobot.v2.orchestrator_async import OrchestratorAsync
+from autobot.v2.orchestrator_services import DecisionJournalService
+
+
+class _Journal:
+    def __init__(self):
+        self.calls = []
+
+    def log(self, **kwargs):
+        self.calls.append(kwargs)
+
+
+def test_orchestrator_journal_methods_are_wired_to_service():
+    orchestrator = OrchestratorAsync.__new__(OrchestratorAsync)
+    journal = _Journal()
+    orchestrator.decision_journal_service = DecisionJournalService(journal=journal, enabled=True)
+
+    orchestrator._journal_major_decision(
+        decision_type="ranking_decision",
+        source="pair_ranking_engine",
+        symbols=["BTC/USD"],
+        reasons=["refresh"],
+        context={"rank": 1},
+    )
+    orchestrator._journal_rejected_opportunity(
+        reason="symbol_not_selected",
+        source="instance_activation_policy",
+        symbol="ETH/USD",
+        context={"tier": 1},
+    )
+
+    assert len(journal.calls) == 2
+    assert orchestrator._fingerprint({"b": 1, "a": 2}) == '{"a": 2, "b": 1}'

--- a/tests/test_orchestrator_services_activation.py
+++ b/tests/test_orchestrator_services_activation.py
@@ -1,0 +1,42 @@
+from autobot.v2.instance_activation_manager import InstanceActivationManager
+from autobot.v2.orchestrator_services import ActivationContext, InstanceActivationService
+from autobot.v2.scalability_guard import ScalingState
+
+
+def test_instance_activation_service_returns_decision_payload():
+    manager = InstanceActivationManager(
+        default_tier=2,
+        promote_score_min=0.5,
+        demote_score_max=0.3,
+        promote_health_min=0.7,
+        demote_health_max=0.4,
+        hysteresis_cycles=1,
+        cooldown_seconds=0,
+    )
+    service = InstanceActivationService(manager)
+    context = ActivationContext(
+        ranked_symbols=["BTC/USD", "ETH/USD", "XRP/USD"],
+        scored_map={
+            "BTC/USD": {"score": 0.9},
+            "ETH/USD": {"score": 0.7},
+            "XRP/USD": {"score": 0.1},
+        },
+        guard_state=ScalingState.ALLOW_SCALE_UP,
+        health_score=0.8,
+        running_instances=1,
+        now_ts=100.0,
+    )
+
+    result = service.apply(context)
+
+    assert result is not None
+    assert result.target_instances >= 1
+    assert "action" in result.payload
+    assert "XRP/USD" in result.rejected_symbols
+
+
+def test_instance_activation_service_below_threshold_symbols():
+    symbols = ["BTC/USD", "ETH/USD"]
+    scored = {"BTC/USD": {"score": 0.8}, "ETH/USD": {"score": 0.0}}
+    lows = InstanceActivationService.below_threshold_symbols(symbols, scored)
+    assert "ETH/USD" in lows

--- a/tests/test_orchestrator_services_background_tasks.py
+++ b/tests/test_orchestrator_services_background_tasks.py
@@ -1,0 +1,25 @@
+import asyncio
+
+import pytest
+
+from autobot.v2.orchestrator_services import BackgroundTasksService
+
+
+@pytest.mark.asyncio
+async def test_background_tasks_service_start_and_stop():
+    service = BackgroundTasksService()
+    ticked = asyncio.Event()
+
+    async def _loop():
+        while True:
+            ticked.set()
+            await asyncio.sleep(0.01)
+
+    service.start({"worker": _loop})
+    await asyncio.wait_for(ticked.wait(), timeout=1.0)
+
+    assert "worker" in service.tasks
+    assert not service.tasks["worker"].done()
+
+    await service.stop(["worker"])
+    assert "worker" not in service.tasks

--- a/tests/test_orchestrator_services_decision_journal.py
+++ b/tests/test_orchestrator_services_decision_journal.py
@@ -1,0 +1,34 @@
+from autobot.v2.orchestrator_services import DecisionJournalService
+
+
+class _Journal:
+    def __init__(self):
+        self.calls = []
+
+    def log(self, **kwargs):
+        self.calls.append(kwargs)
+
+
+def test_decision_journal_service_logs_when_enabled(monkeypatch):
+    monkeypatch.setenv("DECISION_JOURNAL_SESSION_ID", "session-1")
+    journal = _Journal()
+    service = DecisionJournalService(journal, enabled=True)
+
+    service.major_decision(
+        decision_type="activation_decision",
+        source="test",
+        symbols=["BTC/USD"],
+        reasons=["promote"],
+        context={"k": 1},
+    )
+
+    assert len(journal.calls) == 1
+    assert journal.calls[0]["session_id"] == "session-1"
+    assert service.fingerprint({"b": 1, "a": 2}) == '{"a": 2, "b": 1}'
+
+
+def test_decision_journal_service_skips_when_disabled():
+    journal = _Journal()
+    service = DecisionJournalService(journal, enabled=False)
+    service.rejected_opportunity(reason="blocked", source="test", symbol="ETH/USD")
+    assert journal.calls == []

--- a/tests/test_orchestrator_services_portfolio_lifecycle.py
+++ b/tests/test_orchestrator_services_portfolio_lifecycle.py
@@ -1,0 +1,54 @@
+from types import SimpleNamespace
+
+from autobot.v2.orchestrator_services import InstanceLifecycleService, PortfolioAllocationService
+from autobot.v2.portfolio_allocator import AllocationConstraints, PortfolioAllocator
+from autobot.v2.risk_cluster_manager import RiskClusterManager
+
+
+class _Inst:
+    def __init__(self, symbol: str, cap: float, running: bool, pf30: float = 1.0):
+        self.config = SimpleNamespace(symbol=symbol)
+        self._cap = cap
+        self._running = running
+        self._pf30 = pf30
+
+    def is_running(self):
+        return self._running
+
+    def get_current_capital(self):
+        return self._cap
+
+    def get_profit_factor_days(self, _days: int):
+        return self._pf30
+
+
+def test_portfolio_allocation_service_builds_plan():
+    allocator = PortfolioAllocator(
+        AllocationConstraints(
+            max_capital_per_instance_ratio=0.5,
+            max_capital_per_cluster_ratio=0.6,
+            reserve_cash_ratio=0.1,
+            max_total_active_risk_ratio=0.3,
+            risk_per_capital_ratio=0.05,
+        )
+    )
+    service = PortfolioAllocationService(allocator, RiskClusterManager(cluster_cap=0.5))
+    instances = [_Inst("BTC/USD", 1000.0, True), _Inst("ETH/USD", 800.0, True)]
+
+    plan = service.refresh_plan(
+        instances=instances,
+        fallback_instances=instances,
+        ranked_symbols=["BTC/USD", "ETH/USD"],
+    )
+
+    assert plan is not None
+    assert plan.total_allocated >= 0.0
+    assert len(plan.symbol_caps) >= 1
+
+
+def test_instance_lifecycle_service_selects_lowest_pf_first():
+    service = InstanceLifecycleService()
+    instances = [_Inst("BTC/USD", 1000.0, True, pf30=1.5), _Inst("ETH/USD", 1000.0, True, pf30=0.8)]
+    victims = service.select_worst_by_pf(instances, 1)
+    assert len(victims) == 1
+    assert victims[0].config.symbol == "ETH/USD"

--- a/tests/test_orchestrator_services_scalability.py
+++ b/tests/test_orchestrator_services_scalability.py
@@ -1,0 +1,35 @@
+from autobot.v2.orchestrator_services import ScalabilityGuardService, ScalabilityMetrics
+from autobot.v2.scalability_guard import GuardThresholds, ScalabilityGuard
+
+
+def test_scalability_guard_service_evaluates_state():
+    guard = ScalabilityGuard(
+        GuardThresholds(
+            cpu_pct_max=50.0,
+            memory_pct_max=80.0,
+            ws_stale_seconds_max=10.0,
+            ws_lag_max=100,
+            execution_failure_rate_max=0.2,
+            reconciliation_mismatch_max=0.5,
+        )
+    )
+    service = ScalabilityGuardService(guard)
+
+    decision = service.evaluate(
+        ScalabilityMetrics(
+            cpu_pct=95.0,
+            memory_pct=90.0,
+            ws_connected=True,
+            ws_stale_seconds=0.0,
+            ws_total_lag=0,
+            execution_failure_rate=0.0,
+            reconciliation_mismatch_ratio=0.0,
+            kill_switch_tripped=False,
+            pf_degraded=False,
+            validation_degraded=False,
+        )
+    )
+
+    assert decision is not None
+    assert decision.state.value in {"FREEZE", "FORCE_REDUCE", "ALLOW_SCALE_UP"}
+    assert decision.reasons


### PR DESCRIPTION
### Motivation
- Reduce coupling inside the large `OrchestratorAsync` by extracting dedicated services for lifecycle, scaling/activation, allocation, decision journaling and background tasks. 
- Make interactions explicit via small interfaces (`Protocol`) and simple data contracts (`dataclass`) so the orchestrator can remain a thin composer and scheduler. 
- Improve testability by enabling unit tests for each service without requiring real external dependencies (e.g. Kraken). 

### Description
- Added `src/autobot/v2/orchestrator_services.py` which implements `DecisionJournalService`, `ScalabilityGuardService`, `InstanceActivationService`, `PortfolioAllocationService`, `InstanceLifecycleService`, and `BackgroundTasksService`, plus `Protocol` and `dataclass` types (`JournalLike`, `InstanceLike`, `ScalabilityMetrics`, `ActivationContext`, `ActivationResult`).
- Refactored `OrchestratorAsync` to instantiate and delegate to the new services (`decision_journal_service`, `scalability_guard_service`, `instance_activation_service`, `portfolio_allocation_service`, `lifecycle_service`, `background_tasks`) and replaced inline logic with service calls (guard evaluation, activation policy, portfolio refresh, victim selection, journal/fingerprint usage, background task lifecycle).
- Centralized background loops start/stop through `BackgroundTasksService` instead of repeatedly calling `asyncio.create_task` and manual cancellation, and introduced `journal_symbol_cap()` usage to unify journal symbol limits.
- Kept the orchestrator focused on composition and scheduling while migrating implementation details into the extracted services to enable smaller, targeted units of code.

### Testing
- Added focused unit tests for each service: `tests/test_orchestrator_services_decision_journal.py`, `tests/test_orchestrator_services_activation.py`, `tests/test_orchestrator_services_portfolio_lifecycle.py`, `tests/test_orchestrator_services_background_tasks.py`, and `tests/test_orchestrator_services_scalability.py`.
- Added a minimal orchestrator wiring test `tests/test_orchestrator_async_wiring.py` that validates `OrchestratorAsync` delegates journaling and fingerprinting to the journal service.
- Ran `pytest -q tests/test_orchestrator_services_decision_journal.py tests/test_orchestrator_services_activation.py tests/test_orchestrator_services_portfolio_lifecycle.py tests/test_orchestrator_services_background_tasks.py tests/test_orchestrator_services_scalability.py tests/test_orchestrator_async_wiring.py` and all listed tests passed (`9 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e80f19e214832fba33ad2d76b50714)