### PR TITLE
Reset ErrorHandler failure counter on success and add regression tests

### DIFF
--- a/src/autobot/error_handler.py
+++ b/src/autobot/error_handler.py
@@ -100,6 +100,9 @@ class ErrorHandler:
     
     def _record_success(self):
         """Enregistre un succès (ferme le circuit si half-open)"""
+        if self._circuit_state == CircuitState.CLOSED:
+            self._failure_count = 0
+
         if self._circuit_state == CircuitState.HALF_OPEN:
             logger.info("✅ Circuit breaker: Récupération réussie, circuit FERMÉ")
             self._circuit_state = CircuitState.CLOSED

--- a/tests/test_error_handler.py
+++ b/tests/test_error_handler.py
@@ -1,0 +1,74 @@
+import pytest
+
+from autobot.error_handler import (
+    CircuitBreakerOpenError,
+    CircuitState,
+    ErrorHandler,
+)
+
+
+def test_circuit_opens_only_after_consecutive_failures_with_resets():
+    handler = ErrorHandler(
+        max_retries=1,
+        circuit_failure_threshold=3,
+        retry_delay=0,
+    )
+
+    def fail_once():
+        raise RuntimeError("boom")
+
+    def succeed():
+        return "ok"
+
+    # échec, succès, échec, succès
+    with pytest.raises(RuntimeError):
+        handler.execute_with_retry(fail_once)
+    assert handler._failure_count == 1
+    assert handler.circuit_state == CircuitState.CLOSED
+
+    assert handler.execute_with_retry(succeed) == "ok"
+    assert handler._failure_count == 0
+    assert handler.circuit_state == CircuitState.CLOSED
+
+    with pytest.raises(RuntimeError):
+        handler.execute_with_retry(fail_once)
+    assert handler._failure_count == 1
+    assert handler.circuit_state == CircuitState.CLOSED
+
+    assert handler.execute_with_retry(succeed) == "ok"
+    assert handler._failure_count == 0
+    assert handler.circuit_state == CircuitState.CLOSED
+
+    # puis échecs successifs -> ouverture uniquement au seuil
+    with pytest.raises(RuntimeError):
+        handler.execute_with_retry(fail_once)
+    assert handler._failure_count == 1
+    assert handler.circuit_state == CircuitState.CLOSED
+
+    with pytest.raises(RuntimeError):
+        handler.execute_with_retry(fail_once)
+    assert handler._failure_count == 2
+    assert handler.circuit_state == CircuitState.CLOSED
+
+    with pytest.raises(RuntimeError):
+        handler.execute_with_retry(fail_once)
+    assert handler._failure_count == 3
+    assert handler.circuit_state == CircuitState.OPEN
+
+
+def test_execute_with_retry_keeps_raising_circuit_breaker_on_error_cascade(monkeypatch):
+    handler = ErrorHandler(
+        max_retries=5,
+        circuit_failure_threshold=2,
+        retry_delay=0,
+    )
+
+    monkeypatch.setattr("autobot.error_handler.time.sleep", lambda _delay: None)
+
+    def always_fail():
+        raise RuntimeError("cascade")
+
+    with pytest.raises(CircuitBreakerOpenError, match="Circuit ouvert après 2 échecs"):
+        handler.execute_with_retry(always_fail)
+
+    assert handler.circuit_state == CircuitState.OPEN


### PR DESCRIPTION
### Motivation
- Ensure the circuit breaker only opens after truly consecutive failures by resetting the failure counter on successful calls while the circuit is `CLOSED`.
- Preserve the existing behavior that a success from `HALF_OPEN` closes the circuit and clears the counter.
- Verify that `execute_with_retry()` still raises `CircuitBreakerOpenError` during real cascading error scenarios where the threshold is reached during retries.

### Description
- Reset `_failure_count` to `0` in `_record_success()` when the circuit is `CLOSED` in `src/autobot/error_handler.py`.
- Keep the existing `HALF_OPEN -> CLOSED` recovery behavior and counter reset unchanged in `src/autobot/error_handler.py`.
- Add `tests/test_error_handler.py` containing two unit tests: one that exercises the sequence fail/success/fail/success/then-fails and asserts the circuit opens only after `circuit_failure_threshold` consecutive failures, and one that confirms `execute_with_retry()` still raises `CircuitBreakerOpenError` on an error cascade.

### Testing
- Ran `pytest -q tests/test_error_handler.py` and both tests passed (`2 passed`).
- The changes touch `src/autobot/error_handler.py` and add `tests/test_error_handler.py` and the new tests were executed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e81488180c832f8d5f1be75f3380bf)