### PR TITLE
Enforce non-null order IDs in position tracking

### DIFF
--- a/src/autobot/position_manager.py
+++ b/src/autobot/position_manager.py
@@ -3,7 +3,7 @@ Position Manager - Gestion des positions et cycle BUY→SELL
 """
 
 import logging
-from typing import Dict, List, Optional, Callable
+from typing import Dict, List, Optional, Callable, cast
 from dataclasses import dataclass
 from enum import Enum
 
@@ -154,6 +154,12 @@ class PositionManager:
         """
         if not buy_order.is_buy():
             raise ValueError("L'ordre doit être un ordre d'achat (BUY)")
+
+        # Contrat: un ordre BUY tracké doit toujours avoir un identifiant non nul.
+        if not buy_order.id:
+            raise ValueError("buy_order.id manquant")
+
+        buy_order_id = cast(str, buy_order.id)
         
         # Vérifie la limite de positions
         if not self.can_open_position():
@@ -164,17 +170,17 @@ class PositionManager:
             return None
         
         position = Position(
-            buy_order_id=buy_order.id,
+            buy_order_id=buy_order_id,
             buy_price=buy_order.price,
             volume=buy_order.volume,
             status=PositionStatus.OPEN
         )
         
-        self._positions[buy_order.id] = position
+        self._positions[buy_order_id] = position
         
         logger.info(
             f"📊 Position ouverte: BUY {buy_order.volume} @ €{buy_order.price:,.2f} "
-            f"(ID: {buy_order.id}) - {len(self.get_open_positions())}/{self.max_positions}"
+            f"(ID: {buy_order_id}) - {len(self.get_open_positions())}/{self.max_positions}"
         )
         
         return position
@@ -184,7 +190,7 @@ class PositionManager:
         Vérifie si un ordre BUY est rempli et crée l'ordre SELL correspondant.
         
         Args:
-            buy_order_id: ID de l'ordre BUY
+            buy_order_id: ID non-null de l'ordre BUY
             
         Returns:
             Position mise à jour si remplie, None sinon
@@ -228,14 +234,18 @@ class PositionManager:
                 volume=buy_order.volume
             )
             
+            if not sell_order.id:
+                raise ValueError("sell_order.id manquant")
+            sell_order_id = cast(str, sell_order.id)
+
             # Met à jour la position
-            position.sell_order_id = sell_order.id
+            position.sell_order_id = sell_order_id
             position.sell_price = sell_price
             position.status = PositionStatus.FILLED
             position.profit = position.calculate_profit()
             
             # Indexe par sell_order_id pour suivi futur
-            self._positions_by_sell[sell_order.id] = buy_order_id
+            self._positions_by_sell[sell_order_id] = buy_order_id
             
             logger.info(
                 f"📈 Ordre SELL placé: {buy_order.volume} @ €{sell_price:,.2f} "

--- a/tests/test_position_manager.py
+++ b/tests/test_position_manager.py
@@ -1,0 +1,95 @@
+from autobot.order_manager import Order, OrderSide
+from autobot.position_manager import PositionManager, PositionStatus
+
+
+class _DummyGridCalculator:
+    def get_sell_levels(self):
+        return [101.0, 102.0]
+
+
+class _DummyOrderManager:
+    def __init__(self):
+        self._buy_order = None
+        self._sell_order = None
+        self.canceled = []
+
+    def get_order_status(self, order_id, force_refresh=False):
+        if self._buy_order and order_id == self._buy_order.id:
+            return self._buy_order
+        if self._sell_order and order_id == self._sell_order.id:
+            return self._sell_order
+        return None
+
+    def place_sell_order(self, symbol, price, volume):
+        return self._sell_order
+
+    def cancel_order(self, order_id):
+        self.canceled.append(order_id)
+        return True
+
+
+def test_open_position_rejects_missing_buy_order_id():
+    manager = PositionManager(_DummyOrderManager(), _DummyGridCalculator())
+    buy_order = Order(
+        id=None,
+        symbol="XXBTZEUR",
+        side=OrderSide.BUY,
+        price=100.0,
+        volume=0.01,
+    )
+
+    try:
+        manager.open_position(buy_order)
+        assert False, "Expected ValueError"
+    except ValueError as exc:
+        assert "buy_order.id manquant" in str(exc)
+
+
+def test_open_position_tracks_with_non_null_buy_order_id():
+    manager = PositionManager(_DummyOrderManager(), _DummyGridCalculator())
+    buy_order = Order(
+        id="buy_1",
+        symbol="XXBTZEUR",
+        side=OrderSide.BUY,
+        price=100.0,
+        volume=0.01,
+    )
+
+    position = manager.open_position(buy_order)
+
+    assert position is not None
+    assert position.buy_order_id == "buy_1"
+    assert "buy_1" in manager._positions
+
+
+def test_check_and_fill_position_does_not_index_none_sell_id():
+    order_manager = _DummyOrderManager()
+    manager = PositionManager(order_manager, _DummyGridCalculator())
+
+    buy_order = Order(
+        id="buy_2",
+        symbol="XXBTZEUR",
+        side=OrderSide.BUY,
+        price=100.0,
+        volume=0.01,
+        status="closed",
+        filled_volume=0.01,
+    )
+    order_manager._buy_order = buy_order
+    order_manager._sell_order = Order(
+        id=None,
+        symbol="XXBTZEUR",
+        side=OrderSide.SELL,
+        price=101.0,
+        volume=0.01,
+        status="open",
+    )
+
+    opened = manager.open_position(buy_order)
+    assert opened is not None
+
+    filled = manager.check_and_fill_position("buy_2")
+
+    assert filled is None
+    assert manager._positions_by_sell == {}
+    assert manager._positions["buy_2"].status != PositionStatus.FILLED


### PR DESCRIPTION
### Motivation

- Éviter le suivi de positions avec des clés potentiellement `None` qui provoquent des incohérences lors du mapping `buy_order_id -> Position` et `sell_order_id -> buy_order_id`.
- Clarifier le contrat d'usage : un ordre BUY suivi doit disposer d'un `id` non-null au moment de l'ouverture et du tracking.

### Description

- Ajout d'une garde dans `PositionManager.open_position` pour lever `ValueError("buy_order.id manquant")` si `buy_order.id` est vide ou `None`, puis utilisation de cet ID (casté) comme clé de suivi dans `self._positions` (`src/autobot/position_manager.py`).
- Clarification du docstring de `check_and_fill_position` indiquant que `buy_order_id` doit être non-null et renforcement du flux SELL en vérifiant que `sell_order.id` existe avant d'indexer `_positions_by_sell`, en utilisant `cast` pour fixer le type (`src/autobot/position_manager.py`).
- Remplacement des usages directs de `order.id` par la variable sécurisée `buy_order_id` / `sell_order_id` pour garantir qu'aucune clé `None` n'est insérée.
- Ajout d'un fichier de tests ciblés `tests/test_position_manager.py` qui couvre les cas de BUY sans `id`, ouverture normale avec `id` et protection contre l'indexation d'un SELL sans `id`.

### Testing

- Exécution des tests unitaires ciblés avec `pytest -q tests/test_position_manager.py` — résultat : `3 passed`.
- Les nouveaux tests valident le comportement attendu des fonctions `open_position` et `check_and_fill_position` et confirment l'absence d'indexation avec clés `None`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e814873340832f950d2b8d8653182e)