### PR TITLE
ci: deduplicate python-tests job in security-and-audit workflow

### DIFF
--- a/.github/workflows/security-and-audit.yml
+++ b/.github/workflows/security-and-audit.yml
@@ -28,7 +28,8 @@ jobs:
           inputs: requirements.txt
 
   python-tests:
-    name: Python tests (${{ matrix.test_suite }})
+    # Source unique de vérité pour l'exécution des tests Python en CI.
+    name: Python tests (unit|integration)
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -81,42 +82,6 @@ jobs:
         run: npm ci
       - name: Run npm audit (high+)
         run: npm audit --audit-level=high
-
-  python-tests:
-    name: Python tests (${{ matrix.suite }})
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        suite: [unit, integration]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-          cache: pip
-          cache-dependency-path: requirements.txt
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-      - name: Run pytest - unit
-        if: matrix.suite == 'unit'
-        run: |
-          pytest -q -m "not integration" --junitxml=pytest-unit.xml
-      - name: Run pytest - integration
-        if: matrix.suite == 'integration'
-        run: |
-          pytest -q -m "integration" --junitxml=pytest-integration.xml
-      - name: Upload pytest artifacts
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: pytest-${{ matrix.suite }}-artifacts
-          path: |
-            pytest-*.xml
-            .pytest_cache
-          if-no-files-found: ignore
 
   dashboard-build-lint:
     name: Dashboard build and lint


### PR DESCRIPTION
### Motivation
- Éliminer la duplication du job `python-tests` pour avoir une source unique de vérité pour l'exécution des tests Python en CI et garantir un `name` stable pour la protection des branches.

### Description
- Supprime le job dupliqué et conserve un seul job `python-tests` (matrice `unit`/`integration`) dans `/.github/workflows/security-and-audit.yml`, ajoute un commentaire en tête précisant qu'il est la source unique de vérité, fixe le `name` à `Python tests (unit|integration)`, et préserve l'installation des dépendances (`pip install -r requirements.txt`), l'exécution séparée de `pytest` avec génération de JUnit/logs dans `artifacts/python-tests/` et l'upload d'artifacts avec `if: always()`.

### Testing
- Aucun test automatisé local n'a été exécuté; la modification concerne la configuration CI et sera validée par GitHub Actions lors du prochain push/PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e818875eb8832f821e101891bb2cc8)