### PR TITLE
Aligner les gates CI critiques avec les jobs réels (ajout de conflict-marker-scan)

### DIFF
--- a/.github/workflows/security-and-audit.yml
+++ b/.github/workflows/security-and-audit.yml
@@ -7,6 +7,19 @@ on:
     branches: [ main, master, work ]
 
 jobs:
+  conflict-marker-scan:
+    name: Conflict marker scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Fail if merge conflict markers are present
+        run: |
+          if rg -n --hidden --glob '!**/node_modules/**' '^(<<<<<<<|=======|>>>>>>>)' .; then
+            echo "Merge conflict markers detected. Resolve conflicts before merge."
+            exit 1
+          fi
+          echo "No merge conflict markers found."
+
   secret-scan:
     name: Secret scan (gitleaks)
     runs-on: ubuntu-latest
@@ -153,6 +166,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request' && (github.base_ref == 'main' || github.base_ref == 'master' || github.base_ref == 'work')
     needs:
+      - conflict-marker-scan
       - python-tests
       - dashboard-build-lint
     steps:

--- a/docs/CI_REQUIRED_CHECKS.md
+++ b/docs/CI_REQUIRED_CHECKS.md
@@ -6,9 +6,9 @@ For pull requests targeting critical branches (`main`, `master`, `work`), requir
 
 This gate depends on:
 
+- `Conflict marker scan` (job id: `conflict-marker-scan` in `.github/workflows/security-and-audit.yml`).
 - `Python tests (unit)` and `Python tests (integration)` from the `python-tests` matrix job.
-- `Dashboard build and lint`.
-- `Conflict marker scan`.
+- `Dashboard build and lint` (job id: `dashboard-build-lint`).
 
 Recommended GitHub configuration:
 
@@ -18,6 +18,18 @@ Recommended GitHub configuration:
 4. Mark `Required CI gates (critical branches)` as required.
 
 Artifacts are published for diagnostics even when jobs fail.
+
+## Single source of truth
+
+To avoid drift between documentation and CI behavior:
+
+1. Treat `.github/workflows/security-and-audit.yml` as the authoritative source for required gate wiring.
+2. Keep `required-critical-gates.needs` synchronized with this document using exact job ids:
+   - `conflict-marker-scan`
+   - `python-tests`
+   - `dashboard-build-lint`
+3. Keep the human-readable job name `Required CI gates (critical branches)` listed as the required status check in branch protection.
+4. If a required job is moved to another workflow, create a dedicated aggregator in that target workflow and update this file in the same PR.
 
 
 Additionally, enforce the dedicated pre-merge routine described in `docs/PRE_MERGE_ROUTINE.md`.


### PR DESCRIPTION
### Motivation

- Aligner le gate `Required CI gates (critical branches)` avec les jobs réellement requis pour que le scan des marqueurs de conflit puisse être rendu bloqueur dans le même workflow.
- Rendre la documentation exacte et maintenir une source unique de vérité pour éviter les dérives entre doc et wiring CI.

### Description

- Ajout du job `conflict-marker-scan` dans `.github/workflows/security-and-audit.yml` qui recherche les marqueurs de conflit (`<<<<<<<`, `=======`, `>>>>>>>`) et échoue si trouvés.
- Ajout explicite de `conflict-marker-scan` à `required-critical-gates.needs` aux côtés de `python-tests` et `dashboard-build-lint` dans `.github/workflows/security-and-audit.yml`.
- Mise à jour de `docs/CI_REQUIRED_CHECKS.md` pour référencer les identifiants de job exacts (`conflict-marker-scan`, `python-tests`, `dashboard-build-lint`) et ajout d'une section `Single source of truth` avec consignes de synchronisation.

### Testing

- Vérification de la syntaxe et du contenu YAML via `ruby -e "require 'yaml'; data=YAML.load_file('.github/workflows/security-and-audit.yml'); puts data['jobs'].keys.join(', '); p data['jobs']['required-critical-gates']['needs']"` qui a confirmé que `required-critical-gates.needs` contient `conflict-marker-scan`, `python-tests`, et `dashboard-build-lint`.
- Tentative de parsing YAML en Python via un script `python -c 'import yaml; ...'` a échoué car le module `yaml` n'est pas installé dans l'environnement (outil non disponible, échec attendu et non bloquant pour la validation du changement).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e818888580832f85a058b39cfafc59)