### PR TITLE
ci: add frontend test job, publish dashboard test artifacts, and split lint/test from build

### DIFF
--- a/.github/workflows/dashboard-build.yml
+++ b/.github/workflows/dashboard-build.yml
@@ -12,9 +12,43 @@ on:
       - '.github/workflows/dashboard-build.yml'
 
 jobs:
-  build-dashboard:
+  dashboard-lint-test:
+    name: Dashboard lint and test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: dashboard
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: dashboard/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+      - name: Lint dashboard
+        run: npm run lint
+      - name: Run dashboard tests (verbose)
+        run: |
+          mkdir -p ../artifacts/dashboard-tests
+          set -o pipefail
+          npm run test -- --reporter=verbose 2>&1 | tee ../artifacts/dashboard-tests/test.log
+      - name: Upload dashboard test artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dashboard-test-artifacts
+          path: |
+            artifacts/dashboard-tests/
+            dashboard/coverage/
+          if-no-files-found: ignore
+          retention-days: 14
+
+  dashboard-build:
     name: Build dashboard artifacts in CI/CD
     runs-on: ubuntu-latest
+    needs: dashboard-lint-test
     defaults:
       run:
         working-directory: dashboard
@@ -29,3 +63,14 @@ jobs:
         run: npm ci
       - name: Build dashboard
         run: npm run build
+      - name: Upload dashboard build artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dashboard-build-artifacts
+          path: |
+            dashboard/dist/
+            dashboard/npm-debug.log*
+            dashboard/.npm/_logs/
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.github/workflows/security-and-audit.yml
+++ b/.github/workflows/security-and-audit.yml
@@ -118,8 +118,8 @@ jobs:
             .pytest_cache
           if-no-files-found: ignore
 
-  dashboard-build-lint:
-    name: Dashboard build and lint
+  dashboard-lint-test:
+    name: Dashboard lint and test
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -135,6 +135,38 @@ jobs:
         run: npm ci
       - name: Lint
         run: npm run lint
+      - name: Run frontend tests (verbose)
+        run: |
+          mkdir -p ../artifacts/dashboard-tests
+          set -o pipefail
+          npm run test -- --reporter=verbose 2>&1 | tee ../artifacts/dashboard-tests/test.log
+      - name: Upload dashboard test artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dashboard-test-artifacts
+          path: |
+            artifacts/dashboard-tests/
+            dashboard/coverage/
+          if-no-files-found: ignore
+          retention-days: 14
+
+  dashboard-build:
+    name: Build dashboard artifacts in CI/CD
+    runs-on: ubuntu-latest
+    needs: dashboard-lint-test
+    defaults:
+      run:
+        working-directory: dashboard
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: dashboard/package-lock.json
+      - name: Install dependencies
+        run: npm ci
       - name: Build
         run: npm run build
       - name: Upload dashboard artifacts
@@ -154,7 +186,8 @@ jobs:
     if: github.event_name == 'pull_request' && (github.base_ref == 'main' || github.base_ref == 'master' || github.base_ref == 'work')
     needs:
       - python-tests
-      - dashboard-build-lint
+      - dashboard-lint-test
+      - dashboard-build
     steps:
       - name: Confirm required gates passed
         run: echo "All required CI gates passed for critical branch PR."

--- a/docs/CI_REQUIRED_CHECKS.md
+++ b/docs/CI_REQUIRED_CHECKS.md
@@ -7,7 +7,8 @@ For pull requests targeting critical branches (`main`, `master`, `work`), requir
 This gate depends on:
 
 - `Python tests (unit)` and `Python tests (integration)` from the `python-tests` matrix job.
-- `Dashboard build and lint`.
+- `Dashboard lint and test` (frontend test check).
+- `Build dashboard artifacts in CI/CD`.
 - `Conflict marker scan`.
 
 Recommended GitHub configuration:


### PR DESCRIPTION
### Motivation

- Ensure frontend tests run in CI immediately after `npm ci` and produce logs/coverage for diagnostics.
- Publish frontend test artifacts so failures are debuggable and coverage can be inspected.
- Make the dashboard pipeline stricter by splitting lint/test and build so `build` depends on successful lint+tests.
- Enforce the frontend test check on critical branches in branch protection documentation.

### Description

- Split the dashboard workflow into two jobs in `.github/workflows/dashboard-build.yml`: `dashboard-lint-test` (install, lint, run tests) and `dashboard-build` which now `needs: dashboard-lint-test` and uploads build artifacts. 
- Run frontend tests after `npm ci` using `npm run test -- --reporter=verbose` and capture output to `artifacts/dashboard-tests/test.log`, and upload `dashboard/coverage/` when present. 
- Mirror the same `dashboard-lint-test` + `dashboard-build` split and artifacts upload in `.github/workflows/security-and-audit.yml`, and make the `required-critical-gates` job depend on both dashboard jobs. 
- Update `docs/CI_REQUIRED_CHECKS.md` to include `Dashboard lint and test` (frontend test check) and `Build dashboard artifacts in CI/CD` as required dependencies of the `Required CI gates (critical branches)` check.

### Testing

- Verified both modified workflow files parse as YAML using `ruby -e 'require "yaml"; ...'`, which returned `YAML parse OK`.
- Confirmed presence of inserted job names and test commands with `rg` for `dashboard-lint-test`, `Build dashboard artifacts in CI/CD`, and `npm run test -- --reporter=verbose` across the updated files. 
- Attempted a Python YAML load validation with `yaml.safe_load` but it failed because the `yaml` module was not available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e818892d38832fa5964a276347210a)