### PR TITLE
Improve post-trade reconciliation metrics quality and add unit tests

### DIFF
--- a/src/autobot/v2/signal_handler_async.py
+++ b/src/autobot/v2/signal_handler_async.py
@@ -270,17 +270,43 @@ class SignalHandlerAsync:
         divergences = self._reconciler.compare_balances(local_total, exchange_total)
         # Deeper parity: fees / realized / unrealized PnL aggregates
         tb = await self.order_executor.get_trade_balance("EUR")
+        exchange_realized = self._to_optional_float(tb.get("n") if isinstance(tb, dict) else None)
+        exchange_unrealized = self._to_optional_float(tb.get("u") if isinstance(tb, dict) else None)
+        exchange_fees = self._to_optional_float(tb.get("c") if isinstance(tb, dict) else None)
+        local_unrealized = self._compute_unrealized_pnl()
+        local_fees = self._compute_local_fees_aggregate()
+        local_realized = self._to_optional_float(self.instance.get_profit())
+
         exchange_metrics = {
-            "realized_pnl": float(tb.get("n", 0.0) if isinstance(tb.get("n"), (int, float)) else 0.0),
-            "unrealized_pnl": float(tb.get("u", 0.0) if isinstance(tb.get("u"), (int, float)) else 0.0),
-            "fees": float(tb.get("c", 0.0) if isinstance(tb.get("c"), (int, float)) else 0.0),
+            "realized_pnl": exchange_realized,
+            "unrealized_pnl": exchange_unrealized,
+            "fees": exchange_fees,
         }
         local_metrics = {
-            "realized_pnl": float(self.instance.get_profit()),
-            "unrealized_pnl": 0.0,  # TODO: derive mark-to-market from open positions
-            "fees": 0.0,  # TODO: persist/aggregate actual exchange fees in dedicated table
+            "realized_pnl": local_realized,
+            "unrealized_pnl": local_unrealized,
+            "fees": local_fees,
         }
-        divergences.extend(self._reconciler.compare_fills_fees_pnl(local_metrics, exchange_metrics))
+        quality_flags = {
+            "local_realized_available": local_realized is not None,
+            "local_unrealized_quality": getattr(self, "_last_unrealized_pnl_quality", "incomplete"),
+            "local_fees_available": local_fees is not None,
+            "exchange_realized_available": exchange_realized is not None,
+            "exchange_unrealized_available": exchange_unrealized is not None,
+            "exchange_fees_available": exchange_fees is not None,
+        }
+        metrics_quality = self._derive_metrics_quality(quality_flags)
+        logger.info(
+            "📊 Réconciliation métriques qualité=%s (flags=%s)",
+            metrics_quality,
+            quality_flags,
+        )
+        divergences.extend(
+            self._reconciler.compare_fills_fees_pnl(
+                self._normalize_metrics_for_reconciliation(local_metrics),
+                self._normalize_metrics_for_reconciliation(exchange_metrics),
+            )
+        )
         if self._reconciler.should_kill_switch(divergences):
             await self._kill_switch.trigger("reconciliation_mismatch", divergences[0].message)
 
@@ -329,6 +355,50 @@ class SignalHandlerAsync:
         except Exception:
             return 0.0
 
+    def _compute_local_fees_aggregate(self) -> Optional[float]:
+        persistence = getattr(self.instance, "_persistence", None)
+        if persistence is None or not hasattr(persistence, "get_trade_ledger_metrics"):
+            return None
+        try:
+            metrics = persistence.get_trade_ledger_metrics(self.instance.id)
+            return self._to_optional_float(metrics.get("total_fees"))
+        except Exception:
+            logger.exception("❌ Impossible d'agréger les frais locaux (persistence/audit)")
+            return None
+
+    @staticmethod
+    def _normalize_metrics_for_reconciliation(metrics: dict[str, Optional[float]]) -> dict[str, float]:
+        return {
+            "realized_pnl": float(metrics.get("realized_pnl") or 0.0),
+            "unrealized_pnl": float(metrics.get("unrealized_pnl") or 0.0),
+            "fees": float(metrics.get("fees") or 0.0),
+        }
+
+    @staticmethod
+    def _to_optional_float(value: Any) -> Optional[float]:
+        try:
+            if value is None:
+                return None
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _derive_metrics_quality(flags: dict[str, Any]) -> str:
+        required_available = (
+            flags.get("local_realized_available")
+            and flags.get("local_fees_available")
+            and flags.get("exchange_realized_available")
+            and flags.get("exchange_unrealized_available")
+            and flags.get("exchange_fees_available")
+        )
+        unrealized_quality = flags.get("local_unrealized_quality", "incomplete")
+        if not required_available or unrealized_quality == "incomplete":
+            return "incomplet"
+        if unrealized_quality == "estimated":
+            return "estimé"
+        return "complet"
+
     def _compute_exit_levels(self, entry_price: float) -> tuple[float, float, float, float]:
         atr_pct = self._estimate_atr_pct(entry_price)
         sl_pct = max(0.004, atr_pct * self._atr_sl_mult)
@@ -356,16 +426,29 @@ class SignalHandlerAsync:
         total_cost_bps = fee_bps + slippage_bps + spread_bps
         return (expected_move_bps - total_cost_bps) >= self._min_edge_bps
 
-    def _compute_unrealized_pnl(self) -> float:
+    def _compute_unrealized_pnl(self) -> Optional[float]:
         last_price = getattr(self.instance, "_last_price", None)
         if last_price is None:
-            return 0.0
+            self._last_unrealized_pnl_quality = "incomplete"
+            return None
         unrealized = 0.0
+        has_open_position = False
+        has_partial_data = False
         for pos in self.instance.get_positions_snapshot():
             if pos.get("status") != "open":
                 continue
-            buy_price = float(pos.get("buy_price", 0.0))
-            volume = float(pos.get("volume", 0.0))
+            has_open_position = True
+            buy_price = self._to_optional_float(pos.get("buy_price"))
+            volume = self._to_optional_float(pos.get("volume"))
+            if buy_price is None or volume is None:
+                has_partial_data = True
+                continue
             if buy_price > 0 and volume > 0:
                 unrealized += (float(last_price) - buy_price) * volume
+            else:
+                has_partial_data = True
+        if has_open_position and has_partial_data and unrealized == 0.0:
+            self._last_unrealized_pnl_quality = "incomplete"
+            return None
+        self._last_unrealized_pnl_quality = "estimated" if has_partial_data else "complete"
         return unrealized

--- a/tests/test_pf_phase2.py
+++ b/tests/test_pf_phase2.py
@@ -2,6 +2,8 @@ from collections import deque
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 
+import pytest
+
 from autobot.v2.persistence import StatePersistence
 from autobot.v2.pf_validation import apply_cost_sensitivity, walk_forward_validate
 from autobot.v2.signal_handler_async import SignalHandlerAsync
@@ -61,9 +63,50 @@ class _DummyInstance:
     def get_positions_snapshot(self):
         return [{"status": "open", "buy_price": 100.0, "volume": 0.5}]
 
+    def get_current_capital(self):
+        return 1000.0
+
+    def get_profit(self):
+        return 10.0
+
+
+class _DummyPersistence:
+    def __init__(self, total_fees: float | None):
+        self.total_fees = total_fees
+
+    def get_trade_ledger_metrics(self, _instance_id):
+        return {"total_fees": self.total_fees}
+
+
+class _DummyExecutor:
+    def __init__(self, balance_zeur=1000.0, trade_balance=None):
+        self._balance_zeur = balance_zeur
+        self._trade_balance = trade_balance or {}
+
+    async def get_balance(self):
+        return {"ZEUR": self._balance_zeur}
+
+    async def get_trade_balance(self, _asset):
+        return self._trade_balance
+
+
+class _DummyKillSwitch:
+    def __init__(self):
+        self.triggers = []
+        self.freshness_events = []
+
+    def record_balance_freshness(self, ts):
+        self.freshness_events.append(ts)
+
+    async def trigger(self, reason, message):
+        self.triggers.append((reason, message))
+
 
 def test_cost_guard_filters_low_edge_signal():
     h = SignalHandlerAsync(instance=_DummyInstance(), order_executor=None)
+    h._max_spread_bps = 30.0
+    h._tp_rr = 1.5
+    h._min_edge_bps = 15.0
     sig = TradingSignal(
         type=SignalType.BUY,
         symbol="BTC/EUR",
@@ -82,3 +125,56 @@ def test_walk_forward_and_cost_sensitivity_low_compute():
     wf = walk_forward_validate(stressed, train_size=80, test_size=40, step=40, min_test_trades=20)
     assert wf
     assert all(s.trade_count >= 20 for s in wf)
+
+
+@pytest.mark.asyncio
+async def test_post_trade_reconcile_aligned_metrics(caplog):
+    instance = _DummyInstance()
+    instance._persistence = _DummyPersistence(total_fees=1.5)
+    executor = _DummyExecutor(
+        balance_zeur=1000.0,
+        trade_balance={"n": 10.0, "u": 1.0, "c": 1.5},
+    )
+    handler = SignalHandlerAsync(instance=instance, order_executor=executor)
+    handler._kill_switch = _DummyKillSwitch()
+
+    with caplog.at_level("INFO"):
+        await handler._post_trade_reconcile()
+
+    assert handler._kill_switch.triggers == []
+    assert "qualité=complet" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_post_trade_reconcile_detects_real_divergence():
+    instance = _DummyInstance()
+    instance._persistence = _DummyPersistence(total_fees=8.0)
+    executor = _DummyExecutor(
+        balance_zeur=900.0,  # strong cash drift
+        trade_balance={"n": -20.0, "u": 0.0, "c": 0.1},
+    )
+    handler = SignalHandlerAsync(instance=instance, order_executor=executor)
+    handler._kill_switch = _DummyKillSwitch()
+
+    await handler._post_trade_reconcile()
+
+    assert handler._kill_switch.triggers
+    assert handler._kill_switch.triggers[0][0] == "reconciliation_mismatch"
+
+
+@pytest.mark.asyncio
+async def test_post_trade_reconcile_partial_local_data_logs_incomplete(caplog):
+    instance = _DummyInstance()
+    instance._last_price = None
+    instance._persistence = _DummyPersistence(total_fees=None)
+    executor = _DummyExecutor(
+        balance_zeur=1000.0,
+        trade_balance={"n": 10.0, "u": 0.0, "c": 1.0},
+    )
+    handler = SignalHandlerAsync(instance=instance, order_executor=executor)
+    handler._kill_switch = _DummyKillSwitch()
+
+    with caplog.at_level("INFO"):
+        await handler._post_trade_reconcile()
+
+    assert "qualité=incomplet" in caplog.text


### PR DESCRIPTION
### Motivation
- Make reconciliation use real computed metrics instead of silent zeros so mismatches are diagnosable and safer.
- Surface local audit/persistence fees and mark-to-market unrealized PnL with an explicit data-quality model to avoid hiding missing data.
- Add unit coverage for reconciliation edge cases to prevent regressions and validate kill-switch behaviour.

### Description
- Replaced hardcoded local unrealized PnL with a call to `_compute_unrealized_pnl()` and changed its signature to return `Optional[float]` with quality tracking via `_last_unrealized_pnl_quality`.
- Introduced local fees aggregation via `_compute_local_fees_aggregate()` (uses `get_trade_ledger_metrics`), and added helpers `_to_optional_float`, `_normalize_metrics_for_reconciliation`, and `_derive_metrics_quality` to manage optional metrics and their normalization at comparison time.
- Changed `_post_trade_reconcile` to emit `None` for unavailable metrics, derive a `metrics_quality` string (`complet`/`estimé`/`incomplet`) from availability flags, log the quality and flags, and only normalize values when calling the strict reconciler.
- Added/updated unit tests in `tests/test_pf_phase2.py` to cover aligned metrics (no kill), a real divergence that triggers the kill switch, and partial/local-missing-data that logs `qualité=incomplet`, and adjusted an existing cost-guard test to initialize required thresholds on the handler for test isolation.

### Testing
- Ran `pytest -q tests/test_pf_phase2.py` and all tests passed (`6 passed`).
- Existing test suite entries touched by this change were validated and adjusted where necessary (cost-guard threshold initialization) to keep behavior consistent.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8188d3374832f8fe86b151f1667bc)