### PR TITLE
Introduce score-based allocation provider and constrained capital weighting

### DIFF
--- a/src/autobot/v2/main_async.py
+++ b/src/autobot/v2/main_async.py
@@ -61,6 +61,7 @@ from autobot.v2.api.dashboard import DashboardServer
 from autobot.v2.order_executor_async import OrderExecutorAsync
 from autobot.v2.kill_switch import KillSwitch
 from autobot.v2.startup_attestation import StartupAttestation, StartupAttestationError
+from autobot.v2.portfolio_allocator import AllocationWeightProvider
 
 logger = logging.getLogger(__name__)
 
@@ -184,20 +185,12 @@ class AutoBotV2Async:
             logger.warning("INITIAL_CAPITAL <= 0 (%.2f), allocations forced to 0", total_capital)
             total_capital = 0.0
         
-        # Capital weighting: BTC and ETH get more (1.5x), alts get standard (1.0x)
-        weights = {}
-        for s in symbols:
-            if "XBT" in s or "BTC" in s:
-                weights[s] = 1.5
-            elif "ETH" in s:
-                weights[s] = 1.3
-            else:
-                weights[s] = 1.0
-        total_weight = sum(weights.values())
-        
+        weight_provider = AllocationWeightProvider()
+        capital_plan = weight_provider.build_weighted_capital_plan(symbols, total_capital)
+
         configs = []
         for symbol in symbols:
-            weighted_capital = total_capital * (weights[symbol] / total_weight)
+            weighted_capital = capital_plan.symbol_caps.get(symbol, 0.0)
             grid_config = _build_grid_config(symbol)
             
             # Friendly name mapping
@@ -219,7 +212,13 @@ class AutoBotV2Async:
                 grid_config=grid_config,
             ))
         
-        logger.info(f"Multi-pair: {len(configs)} pairs, total capital={total_capital}")
+        logger.info(
+            "Multi-pair: %d pairs, total capital=%.2f, reserve_cash=%.2f, investable=%.2f",
+            len(configs),
+            total_capital,
+            capital_plan.reserve_cash,
+            capital_plan.total_allocated,
+        )
         for cfg in configs:
             logger.info(f"  {cfg.symbol}: {cfg.initial_capital:.2f} EUR")
         

--- a/src/autobot/v2/portfolio_allocator.py
+++ b/src/autobot/v2/portfolio_allocator.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict, List
+from typing import Dict, List, Mapping, Optional, Sequence
 
 
 @dataclass(frozen=True)
@@ -15,6 +15,31 @@ class AllocationConstraints:
     risk_per_capital_ratio: float = 0.02
 
 
+@dataclass(frozen=True)
+class WeightConstraints:
+    min_weight: float = 0.05
+    max_weight: float = 0.60
+    reserve_cash_ratio: float = 0.20
+
+
+@dataclass(frozen=True)
+class SymbolMetrics:
+    rolling_profit_factor: Optional[float] = None
+    max_drawdown: Optional[float] = None
+    realized_volatility: Optional[float] = None
+    execution_cost: Optional[float] = None
+    execution_stability: Optional[float] = None
+
+
+@dataclass(frozen=True)
+class ScoreWeights:
+    profit_factor: float = 0.35
+    drawdown: float = 0.20
+    volatility: float = 0.15
+    cost: float = 0.15
+    execution_stability: float = 0.15
+
+
 @dataclass
 class AllocationPlan:
     symbol_caps: Dict[str, float]
@@ -23,6 +48,239 @@ class AllocationPlan:
     risk_budget_remaining: float
     reasons: Dict[str, str] = field(default_factory=dict)
     explain: Dict[str, float] = field(default_factory=dict)
+
+
+class AllocationWeightProvider:
+    """Build score-aware symbol weights with explicit conservative fallback."""
+
+    def __init__(
+        self,
+        *,
+        score_weights: Optional[ScoreWeights] = None,
+        constraints: Optional[WeightConstraints] = None,
+        conservative_score: float = 0.25,
+    ) -> None:
+        self.score_weights = score_weights or ScoreWeights()
+        self.constraints = constraints or WeightConstraints()
+        self.conservative_score = max(0.0, float(conservative_score))
+
+    def conservative_metrics(self) -> SymbolMetrics:
+        return SymbolMetrics(
+            rolling_profit_factor=1.0,
+            max_drawdown=0.30,
+            realized_volatility=0.60,
+            execution_cost=0.003,
+            execution_stability=0.60,
+        )
+
+    def legacy_baseline_metrics(self, symbol: str) -> SymbolMetrics:
+        # Preserve legacy BTC/ETH overweight behaviour as baseline.
+        up = symbol.upper()
+        if "XBT" in up or "BTC" in up:
+            return SymbolMetrics(1.20, 0.20, 0.45, 0.0018, 0.88)
+        if "ETH" in up:
+            return SymbolMetrics(1.14, 0.24, 0.50, 0.0020, 0.84)
+        return SymbolMetrics(1.0, 0.30, 0.62, 0.0028, 0.74)
+
+    def build_weighted_capital_plan(
+        self,
+        symbols: Sequence[str],
+        total_capital: float,
+        metrics_by_symbol: Optional[Mapping[str, SymbolMetrics]] = None,
+    ) -> AllocationPlan:
+        ordered_symbols = list(dict.fromkeys(symbols))
+        total_capital = max(0.0, float(total_capital))
+        reserve_cash = total_capital * self.constraints.reserve_cash_ratio
+        investable = max(0.0, total_capital - reserve_cash)
+        symbol_weights = self.compute_weights(ordered_symbols, metrics_by_symbol=metrics_by_symbol)
+        symbol_caps = {s: round(investable * symbol_weights.get(s, 0.0), 2) for s in ordered_symbols}
+        allocated = sum(symbol_caps.values())
+        if symbol_caps:
+            drift = round(investable - allocated, 2)
+            if drift != 0.0:
+                first = ordered_symbols[0]
+                symbol_caps[first] = round(max(0.0, symbol_caps[first] + drift), 2)
+                allocated = sum(symbol_caps.values())
+
+        return AllocationPlan(
+            symbol_caps=symbol_caps,
+            total_allocated=allocated,
+            reserve_cash=reserve_cash,
+            risk_budget_remaining=0.0,
+            reasons={},
+            explain={
+                "total_capital": total_capital,
+                "reserve_cash_ratio": self.constraints.reserve_cash_ratio,
+                "investable_capital": investable,
+                "min_weight": self.constraints.min_weight,
+                "max_weight": self.constraints.max_weight,
+            },
+        )
+
+    def compute_weights(
+        self,
+        symbols: Sequence[str],
+        metrics_by_symbol: Optional[Mapping[str, SymbolMetrics]] = None,
+    ) -> Dict[str, float]:
+        symbols = list(dict.fromkeys(symbols))
+        if not symbols:
+            return {}
+
+        metrics_map = dict(metrics_by_symbol or {})
+        scores: Dict[str, float] = {}
+        data_quality: Dict[str, float] = {}
+        for symbol in symbols:
+            raw_metrics = metrics_map.get(symbol)
+            if raw_metrics is None:
+                # Keep legacy behaviour if no market telemetry is provided.
+                raw_metrics = self.legacy_baseline_metrics(symbol)
+            score, quality = self._score_symbol(raw_metrics)
+            if quality < 1.0:
+                # Explicit conservative fallback for missing data.
+                score = min(score, self.conservative_score)
+            scores[symbol] = max(0.0, score)
+            data_quality[symbol] = quality
+
+        constrained = self._normalize_with_constraints(scores)
+        if not constrained:
+            # Explicit conservative fallback in pathological case.
+            equal = 1.0 / len(symbols)
+            return {s: equal for s in symbols}
+
+        if any(q < 1.0 for q in data_quality.values()):
+            floor = min(0.20, self.constraints.max_weight)
+            capped_symbols = [symbol for symbol, quality in data_quality.items() if quality < 1.0]
+            excess = 0.0
+            for symbol in capped_symbols:
+                if constrained[symbol] > floor:
+                    excess += constrained[symbol] - floor
+                    constrained[symbol] = floor
+
+            if excess > 0.0:
+                eligible = [
+                    s
+                    for s in symbols
+                    if s not in capped_symbols and constrained[s] < self.constraints.max_weight
+                ]
+                while excess > 1e-12 and eligible:
+                    share = excess / len(eligible)
+                    spent = 0.0
+                    next_eligible: List[str] = []
+                    for symbol in eligible:
+                        room = self.constraints.max_weight - constrained[symbol]
+                        add = min(room, share)
+                        constrained[symbol] += add
+                        spent += add
+                        if room - add > 1e-12:
+                            next_eligible.append(symbol)
+                    excess = max(0.0, excess - spent)
+                    eligible = next_eligible
+
+            constrained = self._normalize_with_constraints(constrained)
+
+        return constrained
+
+    def _score_symbol(self, metrics: SymbolMetrics) -> tuple[float, float]:
+        values = {
+            "profit_factor": metrics.rolling_profit_factor,
+            "drawdown": metrics.max_drawdown,
+            "volatility": metrics.realized_volatility,
+            "cost": metrics.execution_cost,
+            "execution_stability": metrics.execution_stability,
+        }
+        defaults = self.conservative_metrics()
+        default_values = {
+            "profit_factor": defaults.rolling_profit_factor,
+            "drawdown": defaults.max_drawdown,
+            "volatility": defaults.realized_volatility,
+            "cost": defaults.execution_cost,
+            "execution_stability": defaults.execution_stability,
+        }
+
+        quality = 1.0
+        for key, value in list(values.items()):
+            if value is None:
+                values[key] = default_values[key]
+                quality *= 0.75
+
+        profit_n = self._clamp((float(values["profit_factor"]) - 0.8) / 0.8)
+        drawdown_n = self._clamp(1.0 - float(values["drawdown"]) / 0.40)
+        vol_n = self._clamp(1.0 - float(values["volatility"]) / 1.00)
+        cost_n = self._clamp(1.0 - float(values["cost"]) / 0.010)
+        exec_n = self._clamp(float(values["execution_stability"]))
+
+        sw = self.score_weights
+        weighted = (
+            sw.profit_factor * profit_n
+            + sw.drawdown * drawdown_n
+            + sw.volatility * vol_n
+            + sw.cost * cost_n
+            + sw.execution_stability * exec_n
+        )
+        return weighted, quality
+
+    def _normalize_with_constraints(self, scores: Mapping[str, float]) -> Dict[str, float]:
+        if not scores:
+            return {}
+
+        symbols = list(scores.keys())
+        n = len(symbols)
+        min_w = max(0.0, self.constraints.min_weight)
+        max_w = min(1.0, self.constraints.max_weight)
+
+        if min_w * n > 1.0:
+            min_w = 1.0 / n
+        if max_w * n < 1.0:
+            max_w = 1.0 / n
+        if min_w > max_w:
+            min_w = max_w
+
+        budget = 1.0 - (min_w * n)
+        if budget <= 0.0:
+            return {s: round(1.0 / n, 10) for s in symbols}
+
+        normalized = {s: min_w for s in symbols}
+        remaining_cap = {s: max(0.0, max_w - min_w) for s in symbols}
+        priorities = {s: max(0.0, float(scores[s])) for s in symbols}
+        remaining_budget = budget
+        active = {s for s in symbols if remaining_cap[s] > 0.0}
+
+        while remaining_budget > 1e-12 and active:
+            p_sum = sum(priorities[s] for s in active)
+            if p_sum <= 0.0:
+                equal_share = remaining_budget / len(active)
+                for s in list(active):
+                    add = min(equal_share, remaining_cap[s])
+                    normalized[s] += add
+                    remaining_cap[s] -= add
+                    remaining_budget -= add
+                    if remaining_cap[s] <= 1e-12:
+                        active.remove(s)
+                continue
+
+            exhausted: set[str] = set()
+            spent_this_round = 0.0
+            for s in list(active):
+                wanted = remaining_budget * (priorities[s] / p_sum)
+                add = min(wanted, remaining_cap[s])
+                normalized[s] += add
+                remaining_cap[s] -= add
+                spent_this_round += add
+                if remaining_cap[s] <= 1e-12:
+                    exhausted.add(s)
+            remaining_budget = max(0.0, remaining_budget - spent_this_round)
+            active -= exhausted
+            if spent_this_round <= 1e-12:
+                break
+
+        total = sum(normalized.values())
+        if total <= 0:
+            return {s: round(1.0 / n, 10) for s in symbols}
+        return {s: normalized[s] / total for s in symbols}
+
+    @staticmethod
+    def _clamp(value: float, low: float = 0.0, high: float = 1.0) -> float:
+        return max(low, min(high, value))
 
 
 class PortfolioAllocator:

--- a/src/autobot/v2/tests/test_main_async_config.py
+++ b/src/autobot/v2/tests/test_main_async_config.py
@@ -32,7 +32,7 @@ def test_create_all_instance_configs_negative_capital(monkeypatch):
     assert all(cfg.initial_capital == 0.0 for cfg in configs)
 
 
-def test_create_all_instance_configs_weighted_sum_matches_total(monkeypatch):
+def test_create_all_instance_configs_investable_sum_matches_total_minus_cash_reserve(monkeypatch):
     monkeypatch.setenv("TRADING_PAIRS", "XXBTZEUR,XETHZEUR,ADAEUR")
     monkeypatch.setenv("INITIAL_CAPITAL", "1000")
 
@@ -40,4 +40,15 @@ def test_create_all_instance_configs_weighted_sum_matches_total(monkeypatch):
     configs = bot._create_all_instance_configs()
 
     total_allocated = sum(cfg.initial_capital for cfg in configs)
-    assert math.isclose(total_allocated, 1000.0, abs_tol=0.02)
+    assert math.isclose(total_allocated, 800.0, abs_tol=0.02)
+
+
+def test_create_all_instance_configs_legacy_priority_order(monkeypatch):
+    monkeypatch.setenv("TRADING_PAIRS", "XXBTZEUR,XETHZEUR,ADAEUR")
+    monkeypatch.setenv("INITIAL_CAPITAL", "1000")
+
+    bot = AutoBotV2Async()
+    configs = bot._create_all_instance_configs()
+
+    by_symbol = {cfg.symbol: cfg.initial_capital for cfg in configs}
+    assert by_symbol["XXBTZEUR"] > by_symbol["XETHZEUR"] > by_symbol["ADAEUR"]

--- a/src/autobot/v2/tests/test_portfolio_allocator.py
+++ b/src/autobot/v2/tests/test_portfolio_allocator.py
@@ -1,4 +1,10 @@
-from autobot.v2.portfolio_allocator import AllocationConstraints, PortfolioAllocator
+from autobot.v2.portfolio_allocator import (
+    AllocationConstraints,
+    AllocationWeightProvider,
+    PortfolioAllocator,
+    SymbolMetrics,
+    WeightConstraints,
+)
 
 
 def _allocator():
@@ -38,7 +44,6 @@ def test_portfolio_allocator_enforces_per_cluster_cap():
         symbol_to_cluster={"BTC/EUR": "BTC", "BTC/USD": "BTC"},
     )
 
-    # cluster cap = 3000, only ~500 left for BTC cluster across both symbols
     assert sum(plan.symbol_caps.values()) <= 500.0 + 1e-6
 
 
@@ -59,7 +64,6 @@ def test_portfolio_allocator_preserves_reserve_cash():
 
 def test_portfolio_allocator_enforces_max_total_active_risk_cap():
     allocator = _allocator()
-    # active risk cap abs = 2000; current risk already 1990 => tiny room only
     plan = allocator.build_plan(
         ranked_candidates=["BTC/EUR", "ETH/EUR"],
         total_capital=10_000,
@@ -87,3 +91,55 @@ def test_portfolio_allocator_explainability_payload():
     assert "max_cluster_abs" in plan.explain
     assert "max_active_risk_abs" in plan.explain
     assert isinstance(plan.reasons, dict)
+
+
+def test_weight_provider_normalizes_weights_to_one():
+    provider = AllocationWeightProvider(constraints=WeightConstraints(min_weight=0.05, max_weight=0.70))
+    weights = provider.compute_weights(
+        ["XXBTZEUR", "XETHZEUR", "ADAEUR"],
+        metrics_by_symbol={
+            "XXBTZEUR": SymbolMetrics(rolling_profit_factor=1.4, max_drawdown=0.15, realized_volatility=0.30, execution_cost=0.001, execution_stability=0.95),
+            "XETHZEUR": SymbolMetrics(rolling_profit_factor=1.2, max_drawdown=0.20, realized_volatility=0.40, execution_cost=0.002, execution_stability=0.90),
+            "ADAEUR": SymbolMetrics(rolling_profit_factor=0.9, max_drawdown=0.35, realized_volatility=0.70, execution_cost=0.004, execution_stability=0.70),
+        },
+    )
+
+    assert abs(sum(weights.values()) - 1.0) < 1e-9
+
+
+def test_weight_provider_respects_min_max_constraints():
+    provider = AllocationWeightProvider(constraints=WeightConstraints(min_weight=0.10, max_weight=0.50))
+    weights = provider.compute_weights(
+        ["XXBTZEUR", "XETHZEUR", "ADAEUR", "SOLEUR"],
+        metrics_by_symbol={
+            "XXBTZEUR": SymbolMetrics(rolling_profit_factor=2.0, max_drawdown=0.05, realized_volatility=0.20, execution_cost=0.0008, execution_stability=0.98),
+            "XETHZEUR": SymbolMetrics(rolling_profit_factor=0.8, max_drawdown=0.35, realized_volatility=0.80, execution_cost=0.006, execution_stability=0.60),
+            "ADAEUR": SymbolMetrics(rolling_profit_factor=0.8, max_drawdown=0.35, realized_volatility=0.80, execution_cost=0.006, execution_stability=0.60),
+            "SOLEUR": SymbolMetrics(rolling_profit_factor=0.8, max_drawdown=0.35, realized_volatility=0.80, execution_cost=0.006, execution_stability=0.60),
+        },
+    )
+
+    assert all(0.10 - 1e-9 <= w <= 0.50 + 1e-9 for w in weights.values())
+
+
+def test_weight_provider_conservative_fallback_for_missing_data():
+    provider = AllocationWeightProvider(constraints=WeightConstraints(min_weight=0.05, max_weight=0.70))
+    weights = provider.compute_weights(
+        ["XXBTZEUR", "NEWCOIN"],
+        metrics_by_symbol={
+            "XXBTZEUR": SymbolMetrics(rolling_profit_factor=1.5, max_drawdown=0.12, realized_volatility=0.25, execution_cost=0.001, execution_stability=0.95),
+            "NEWCOIN": SymbolMetrics(rolling_profit_factor=None, max_drawdown=None, realized_volatility=None, execution_cost=None, execution_stability=None),
+        },
+    )
+
+    assert weights["NEWCOIN"] <= 0.30 + 1e-9
+    assert weights["XXBTZEUR"] > weights["NEWCOIN"]
+
+
+def test_weight_provider_legacy_baseline_non_regression_ordering():
+    provider = AllocationWeightProvider(constraints=WeightConstraints(min_weight=0.05, max_weight=0.70, reserve_cash_ratio=0.20))
+    plan = provider.build_weighted_capital_plan(["XXBTZEUR", "XETHZEUR", "ADAEUR"], total_capital=1_000)
+
+    assert plan.reserve_cash == 200.0
+    assert plan.total_allocated == 800.0
+    assert plan.symbol_caps["XXBTZEUR"] > plan.symbol_caps["XETHZEUR"] > plan.symbol_caps["ADAEUR"]


### PR DESCRIPTION
### Motivation
- Replace hardcoded per-pair weights with a dedicated provider to centralize allocation logic and make allocation decisions data-driven. 
- Compute a combined score per symbol from multiple telemetry signals (profit factor, drawdown, realized volatility, execution cost, execution stability) to drive capital splits. 
- Enforce operational constraints (min/max per-symbol weights, reserve cash, cluster/instance caps, active risk) and provide a conservative explicit fallback when telemetry is missing. 

### Description
- Added `AllocationWeightProvider`, `SymbolMetrics`, `ScoreWeights`, and `WeightConstraints` to `src/autobot/v2/portfolio_allocator.py` to compute symbol scores and transform them into constrained weights. 
- Implemented a constrained normalization algorithm that applies `min_weight`/`max_weight` bounds, preserves reserve-cash ratio, and rebalances excess weight across eligible symbols. 
- Implemented explicit conservative fallback behavior and legacy baseline metrics (BTC/ETH bias) so ordering is backward-compatible when telemetry is absent. 
- Replaced the hardcoded BTC/ETH weighting in `AutoBotV2Async._create_all_instance_configs` with the new provider and updated logging to include `reserve_cash` and `investable` amounts. 
- Kept existing orchestrator-level `PortfolioAllocator.build_plan` (instance/cluster/risk caps) intact and used the new provider for the initial per-symbol capital split. 

### Testing
- Added and updated unit tests in `src/autobot/v2/tests/test_portfolio_allocator.py` and `src/autobot/v2/tests/test_main_async_config.py` to cover weight normalization, min/max constraint enforcement, missing-data fallback, legacy ordering, and reserve-cash-aware allocation sum. 
- Ran: `pytest -q src/autobot/v2/tests/test_portfolio_allocator.py src/autobot/v2/tests/test_main_async_config.py` and all tests passed (`14 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8188dd400832f8a41998d2b7f7b4a)