### PR TITLE
Make AUTOBOT_FORCE_ENABLE_ALL safe-by-default in async orchestrator

### DIFF
--- a/src/autobot/v2/orchestrator_async.py
+++ b/src/autobot/v2/orchestrator_async.py
@@ -164,6 +164,24 @@ def _env_bool(name: str, default: bool) -> bool:
     return value in ("1", "true", "yes", "on")
 
 
+def _apply_force_enable_all_hardening_flags(hardening_flags: Dict[str, bool]) -> None:
+    if _env_bool("AUTOBOT_FORCE_ENABLE_ALL", False):
+        for flag in (
+            "enable_mean_reversion",
+            "enable_sentiment",
+            "enable_ml",
+            "enable_xgboost",
+            "enable_onchain",
+            "enable_trading_health_score",
+            "enable_shadow_promotion",
+            "enable_shadow_trading",
+            "enable_rebalance",
+            "enable_auto_evolution",
+            "enable_validation_guard",
+        ):
+            hardening_flags[flag] = True
+
+
 def _get_available_capital_real(
     api_key: Optional[str] = None,
     api_secret: Optional[str] = None,
@@ -328,21 +346,7 @@ class OrchestratorAsync:
             "log_conflicts": _env_bool("ENABLE_CONFLICT_LOGGING", True),
         }
         self._module_diagnostics: Dict[str, Dict[str, Any]] = {}
-        if _env_bool("AUTOBOT_FORCE_ENABLE_ALL", True):
-            for flag in (
-                "enable_mean_reversion",
-                "enable_sentiment",
-                "enable_ml",
-                "enable_xgboost",
-                "enable_onchain",
-                "enable_trading_health_score",
-                "enable_shadow_promotion",
-                "enable_shadow_trading",
-                "enable_rebalance",
-                "enable_auto_evolution",
-                "enable_validation_guard",
-            ):
-                self.hardening_flags[flag] = True
+        _apply_force_enable_all_hardening_flags(self.hardening_flags)
         self._dependency_report: Dict[str, List[str]] = {"enabled": [], "disabled": []}
         self._config_validation_notes: List[str] = []
         self.decision = DecisionEngine(self)

--- a/src/autobot/v2/tests/test_orchestrator_async_hardening_flags.py
+++ b/src/autobot/v2/tests/test_orchestrator_async_hardening_flags.py
@@ -1,0 +1,40 @@
+import pytest
+
+from autobot.v2.orchestrator_async import _apply_force_enable_all_hardening_flags
+
+
+pytestmark = pytest.mark.unit
+
+
+def _base_hardening_flags() -> dict[str, bool]:
+    return {
+        "enable_mean_reversion": False,
+        "enable_sentiment": False,
+        "enable_ml": False,
+        "enable_xgboost": False,
+        "enable_onchain": False,
+        "enable_trading_health_score": False,
+        "enable_shadow_promotion": False,
+        "enable_shadow_trading": False,
+        "enable_rebalance": False,
+        "enable_auto_evolution": False,
+        "enable_validation_guard": False,
+    }
+
+
+def test_force_enable_all_unset_keeps_safe_default_without_override(monkeypatch):
+    monkeypatch.delenv("AUTOBOT_FORCE_ENABLE_ALL", raising=False)
+    hardening_flags = _base_hardening_flags()
+
+    _apply_force_enable_all_hardening_flags(hardening_flags)
+
+    assert all(value is False for value in hardening_flags.values())
+
+
+def test_force_enable_all_true_applies_override(monkeypatch):
+    monkeypatch.setenv("AUTOBOT_FORCE_ENABLE_ALL", "true")
+    hardening_flags = _base_hardening_flags()
+
+    _apply_force_enable_all_hardening_flags(hardening_flags)
+
+    assert all(value is True for value in hardening_flags.values())


### PR DESCRIPTION
### Motivation

- Ensure the async orchestrator does not implicitly force-enable all hardening modules by default, adopting a safer default posture.
- Preserve the existing explicit opt-in behavior when `AUTOBOT_FORCE_ENABLE_ALL` is set to a truthy value.

### Description

- Changed the force-enable gate to be opt-in by default by using `_env_bool("AUTOBOT_FORCE_ENABLE_ALL", False)` and extracted the logic into a helper function ` _apply_force_enable_all_hardening_flags(hardening_flags)` in `src/autobot/v2/orchestrator_async.py`.
- Replaced the inline conditional in `OrchestratorAsync.__init__` with a call to the new helper so behavior is unchanged when the env var is explicitly true.
- Added focused unit tests in `src/autobot/v2/tests/test_orchestrator_async_hardening_flags.py` that verify the safe-default contract and the explicit-true override.

### Testing

- Ran `PYTHONPATH=src pytest -q src/autobot/v2/tests/test_orchestrator_async_hardening_flags.py` which passed with `2 passed`.
- Running `pytest -q src/autobot/v2/tests/test_orchestrator_async_hardening_flags.py` without `PYTHONPATH=src` fails in this environment due to import path resolution, which is unrelated to the change itself.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e823ac20d0832fbdfa5754a42550c3)