### PR TITLE
Fix workflow 'needs' to reference dashboard-build-lint job key

### DIFF
--- a/.github/workflows/security-and-audit.yml
+++ b/.github/workflows/security-and-audit.yml
@@ -135,7 +135,7 @@ jobs:
   dashboard-build:
     name: Build dashboard artifacts in CI/CD
     runs-on: ubuntu-latest
-    needs: dashboard-lint-test
+    needs: dashboard-build-lint
     defaults:
       run:
         working-directory: dashboard
@@ -168,7 +168,7 @@ jobs:
     needs:
       - conflict-marker-scan
       - python-tests
-      - dashboard-lint-test
+      - dashboard-build-lint
       - dashboard-build
     steps:
       - name: Confirm required gates passed


### PR DESCRIPTION
### Motivation
- Align `needs` references in `.github/workflows/security-and-audit.yml` to the actual dashboard lint/test job key so downstream jobs depend on the correct lint/test job and the CI graph order remains lint/test → build → required gate aggregator.

### Description
- Replaced stale `dashboard-lint-test` references with `dashboard-build-lint` in the `dashboard-build` job `needs` and in the `required-critical-gates` `needs` list without modifying any job steps.

### Testing
- Validated the workflow YAML and job graph using `ruby` (`YAML.load_file`) which succeeded and confirmed all `needs` references resolve to existing job keys, and an attempted Python-based check failed due to the `PyYAML` module not being installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e827c6f588832f9612e58644cf0ada)