### PR TITLE
Fix dashboard job dependency references in security-and-audit workflow

### DIFF
--- a/.github/workflows/security-and-audit.yml
+++ b/.github/workflows/security-and-audit.yml
@@ -135,7 +135,7 @@ jobs:
   dashboard-build:
     name: Build dashboard artifacts in CI/CD
     runs-on: ubuntu-latest
-    needs: dashboard-lint-test
+    needs: dashboard-build-lint
     defaults:
       run:
         working-directory: dashboard
@@ -168,7 +168,7 @@ jobs:
     needs:
       - conflict-marker-scan
       - python-tests
-      - dashboard-lint-test
+      - dashboard-build-lint
       - dashboard-build
     steps:
       - name: Confirm required gates passed


### PR DESCRIPTION
### Motivation
- Fix broken GitHub Actions job dependencies by aligning `needs` references to the actual dashboard job key so the workflow order remains lint/test → build → required gates.

### Description
- Replace stale `dashboard-lint-test` references with the real job key `dashboard-build-lint` in `.github/workflows/security-and-audit.yml`, updating the `dashboard-build` job `needs` and the `required-critical-gates` job `needs` list.

### Testing
- Validated the workflow YAML and job graph by parsing `.github/workflows/security-and-audit.yml` with a Ruby YAML load script which reported all `needs` entries resolve to existing job keys.
- Attempted Python YAML validation but `PyYAML` was not available in the environment so the Python check was skipped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e827c74260832fb946b923795071bc)