### PR TITLE
fix(ci): align dashboard workflow needs with actual lint/test job key

### DIFF
--- a/.github/workflows/security-and-audit.yml
+++ b/.github/workflows/security-and-audit.yml
@@ -135,7 +135,7 @@ jobs:
   dashboard-build:
     name: Build dashboard artifacts in CI/CD
     runs-on: ubuntu-latest
-    needs: dashboard-lint-test
+    needs: dashboard-build-lint
     defaults:
       run:
         working-directory: dashboard
@@ -168,7 +168,7 @@ jobs:
     needs:
       - conflict-marker-scan
       - python-tests
-      - dashboard-lint-test
+      - dashboard-build-lint
       - dashboard-build
     steps:
       - name: Confirm required gates passed


### PR DESCRIPTION
### Motivation
- The workflow referenced a non-existent job key (`dashboard-lint-test`) causing downstream `needs` to point to an incorrect job, which can break CI ordering for the dashboard pipeline.

### Description
- Replaced stale `needs` references from `dashboard-lint-test` to the correct job key `dashboard-build-lint` in `.github/workflows/security-and-audit.yml` for the `dashboard-build` job and the `required-critical-gates` job.
- Ensured the intended dependency chain is preserved as lint/test → build → required gate aggregator by aligning the job keys.
- Performed a YAML job-graph consistency check to ensure every `needs` entry points to an existing job key.

### Testing
- Ran a YAML consistency check using a Ruby snippet (`require 'yaml' ...`) which reported `YAML_OK` and showed `dashboard-build` now needs `dashboard-build-lint`, and `required-critical-gates` includes `dashboard-build-lint`, so the validation succeeded.
- Attempted a Python YAML parse check but it could not run in this environment because `PyYAML` is not installed (tooling failure, not a workflow error).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e827c74cd0832f8b88941b297c743b)