### PR TITLE
Align startup log-follow hint with async logfile name

### DIFF
--- a/start-autobot.sh
+++ b/start-autobot.sh
@@ -60,7 +60,7 @@ if [ -d "dashboard" ]; then
     echo ""
     echo "📊 Dashboard: http://localhost:5173"
     echo "📈 API Bot:   http://localhost:8080/api/status"
-    echo "📝 Logs:      tail -f autobot.log"
+    echo "📝 Logs:      tail -f autobot_async.log"
     echo ""
     echo "🛑 Pour arrêter: Ctrl+C ou ./stop-autobot.sh"
     echo ""


### PR DESCRIPTION
### Motivation
- Ensure the operator-facing startup message points to the actual async logfile (`autobot_async.log`) so log-follow instructions are accurate.

### Description
- Replace the displayed log-follow command in `start-autobot.sh` from `tail -f autobot.log` to `tail -f autobot_async.log` and confirm documentation already references `autobot_async.log`.

### Testing
- Ran `rg -n "autobot\.log|autobot_async\.log|tail -f" --glob '*.sh' --glob 'README.md' --glob 'docs/**'` and `rg -n "autobot\.log"`, and committed the change with `git commit`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e827ca2be4832f9ec2ba160ce97e03)