### PR TITLE
refactor(dashboard): centralize API auth and remove localStorage token usage

### DIFF
--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -1,0 +1,33 @@
+const API_BASE_URL = import.meta.env.VITE_DASHBOARD_API_BASE_URL || '';
+
+let runtimeApiToken: string | null = import.meta.env.VITE_DASHBOARD_API_TOKEN || null;
+
+export const apiAuth = {
+  setToken(token: string | null) {
+    runtimeApiToken = token && token.trim().length > 0 ? token : null;
+  },
+  clearToken() {
+    runtimeApiToken = null;
+  },
+  getToken() {
+    return runtimeApiToken;
+  },
+};
+
+const buildHeaders = (headers?: HeadersInit): Headers => {
+  const mergedHeaders = new Headers(headers);
+  const token = apiAuth.getToken();
+  if (token) {
+    mergedHeaders.set('Authorization', `Bearer ${token}`);
+  }
+  return mergedHeaders;
+};
+
+export const apiFetch = (path: string, init: RequestInit = {}) => {
+  const url = `${API_BASE_URL}${path}`;
+  return fetch(url, {
+    ...init,
+    credentials: 'include',
+    headers: buildHeaders(init.headers),
+  });
+};

--- a/dashboard/src/pages/Analytics.tsx
+++ b/dashboard/src/pages/Analytics.tsx
@@ -3,12 +3,8 @@ import { AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContai
 import MetricCard from '../components/ui/MetricCard';
 import { PieChart, Target, TrendingUp, Shield, BarChart3 } from 'lucide-react';
 import { calculateRendementPercent } from './analyticsMetrics';
+import { apiFetch } from '../api/client';
 
-const API_BASE_URL = '';
-const API_TOKEN =
-  import.meta.env.VITE_DASHBOARD_API_TOKEN ||
-  window.localStorage.getItem('DASHBOARD_API_TOKEN') ||
-  ''; // no hardcoded secret
 
 
 interface ScalingStatusResponse {
@@ -82,7 +78,7 @@ const Analytics: React.FC = () => {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const capitalRes = await fetch(`${API_BASE_URL}/api/capital`, { headers: { "Authorization": `Bearer ${API_TOKEN}` } });
+        const capitalRes = await apiFetch(`/api/capital`);
         if (capitalRes.ok) {
           const capitalData = await capitalRes.json();
           const pnlPercent = calculateRendementPercent(capitalData, '0.0');
@@ -93,7 +89,7 @@ const Analytics: React.FC = () => {
           }));
         }
 
-        const historyRes = await fetch(`${API_BASE_URL}/api/history?days=7`, { headers: { "Authorization": `Bearer ${API_TOKEN}` } });
+        const historyRes = await apiFetch(`/api/history?days=7`);
         if (historyRes.ok) {
           const historyData = await historyRes.json();
           if (historyData.history && historyData.history.length > 0) {
@@ -106,10 +102,10 @@ const Analytics: React.FC = () => {
 
 
         const [scalingRes, universeRes, opportunitiesRes, allocationRes] = await Promise.all([
-          fetch(`${API_BASE_URL}/api/scaling/status`, { headers: { "Authorization": `Bearer ${API_TOKEN}` } }),
-          fetch(`${API_BASE_URL}/api/universe/status`, { headers: { "Authorization": `Bearer ${API_TOKEN}` } }),
-          fetch(`${API_BASE_URL}/api/opportunities/top?limit=6`, { headers: { "Authorization": `Bearer ${API_TOKEN}` } }),
-          fetch(`${API_BASE_URL}/api/portfolio/allocation`, { headers: { "Authorization": `Bearer ${API_TOKEN}` } }),
+          apiFetch(`/api/scaling/status`),
+          apiFetch(`/api/universe/status`),
+          apiFetch(`/api/opportunities/top?limit=6`),
+          apiFetch(`/api/portfolio/allocation`),
         ]);
         if (scalingRes.ok) setScalingStatus(await scalingRes.json());
         if (universeRes.ok) setUniverseStatus(await universeRes.json());

--- a/dashboard/src/pages/Backtest.tsx
+++ b/dashboard/src/pages/Backtest.tsx
@@ -4,9 +4,8 @@ import MetricCard from '../components/ui/MetricCard';
 import Modal from '../components/ui/Modal';
 import StrategyDetailModal from '../components/ui/StrategyDetailModal';
 import { BarChart3, Brain, Cpu, Target, TrendingUp, Calendar, Loader } from 'lucide-react';
+import { apiFetch } from '../api/client';
 
-const API_BASE_URL = '';
-const API_TOKEN = import.meta.env.VITE_DASHBOARD_API_TOKEN || window.localStorage.getItem('DASHBOARD_API_TOKEN') || '';// no hardcoded secret
 
 export interface Strategy {
   name: string;
@@ -31,7 +30,7 @@ const Backtest: React.FC = () => {
     const fetchData = async () => {
       try {
         // Fetch pour remplir les métriques si disponibles
-        const capitalRes = await fetch(`${API_BASE_URL}/api/capital`, { headers: { "Authorization": `Bearer ${API_TOKEN}` } });
+        const capitalRes = await apiFetch(`/api/capital`);
         if (capitalRes.ok) {
           const data = await capitalRes.json();
           const perf = data.total_invested > 0 
@@ -45,7 +44,7 @@ const Backtest: React.FC = () => {
         }
 
         // Données historiques pour le graphique
-        const historyRes = await fetch(`${API_BASE_URL}/api/history?days=30`, { headers: { "Authorization": `Bearer ${API_TOKEN}` } });
+        const historyRes = await apiFetch(`/api/history?days=30`);
         if (historyRes.ok) {
           const historyData = await historyRes.json();
           if (historyData.history) {

--- a/dashboard/src/pages/Capital.tsx
+++ b/dashboard/src/pages/Capital.tsx
@@ -2,9 +2,8 @@ import React, { useState, useEffect, useCallback } from 'react';
 import { Wallet, DollarSign, CreditCard, TrendingUp, TrendingDown, Loader } from 'lucide-react';
 import MetricCard from '../components/ui/MetricCard';
 import { useAppStore } from '../store/useAppStore';
+import { apiFetch } from '../api/client';
 
-const API_BASE_URL = '';
-const API_TOKEN = import.meta.env.VITE_DASHBOARD_API_TOKEN || window.localStorage.getItem('DASHBOARD_API_TOKEN') || '';// no hardcoded secret
 
 interface CapitalData {
   total_capital: number;
@@ -44,14 +43,14 @@ const Capital: React.FC = () => {
       setError(null);
 
       // Fetch capital details
-      const capitalRes = await fetch(`${API_BASE_URL}/api/capital`, { headers: { "Authorization": `Bearer ${API_TOKEN}` } });
+      const capitalRes = await apiFetch(`/api/capital`);
       if (capitalRes.ok) {
         const data: CapitalData = await capitalRes.json();
         setCapitalData(data);
         setCapitalTotal(data.total_capital);
       } else {
         // Fallback sur /api/status si /api/capital n'existe pas encore
-        const statusRes = await fetch(`${API_BASE_URL}/api/status`, { headers: { "Authorization": `Bearer ${API_TOKEN}` } });
+        const statusRes = await apiFetch(`/api/status`);
         if (!statusRes.ok) throw new Error(`API Error: ${statusRes.status}`);
         const statusData = await statusRes.json();
         const fallback: CapitalData = {
@@ -67,7 +66,7 @@ const Capital: React.FC = () => {
       }
 
       // Fetch recent trades
-      const tradesRes = await fetch(`${API_BASE_URL}/api/trades?limit=10`, { headers: { "Authorization": `Bearer ${API_TOKEN}` } });
+      const tradesRes = await apiFetch(`/api/trades?limit=10`);
       if (tradesRes.ok) {
         const tradesData = await tradesRes.json();
         setTrades(tradesData.trades || []);
@@ -76,7 +75,7 @@ const Capital: React.FC = () => {
       
       // Check if paper mode
       try {
-        const paperRes = await fetch(`${API_BASE_URL}/api/paper-trading/summary`, { headers: { "Authorization": `Bearer ${API_TOKEN}` } });
+        const paperRes = await apiFetch(`/api/paper-trading/summary`);
         if (paperRes.ok) {
           const paperData = await paperRes.json();
           setIsPaperMode(paperData.is_paper_mode === true);

--- a/dashboard/src/pages/Diagnostic.tsx
+++ b/dashboard/src/pages/Diagnostic.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { apiFetch } from '../api/client';
 import { 
   Activity, 
   Server, 
@@ -17,8 +18,6 @@ import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContai
 import Skeleton from 'react-loading-skeleton';
 import 'react-loading-skeleton/dist/skeleton.css';
 
-const API_BASE_URL = '';
-const API_TOKEN = import.meta.env.VITE_DASHBOARD_API_TOKEN || window.localStorage.getItem('DASHBOARD_API_TOKEN') || '';// no hardcoded secret
 
 interface SystemMetrics {
   cpu: {
@@ -239,11 +238,7 @@ const Diagnostic: React.FC = () => {
 
   const fetchSystemMetrics = async () => {
     try {
-      const response = await fetch(`${API_BASE_URL}/api/system`, {
-        headers: {
-          'Authorization': `Bearer ${API_TOKEN}`
-        }
-      });
+      const response = await apiFetch(`/api/system`);
       
       if (!response.ok) {
         throw new Error('Erreur lors de la récupération des métriques');

--- a/dashboard/src/pages/LiveTrading.tsx
+++ b/dashboard/src/pages/LiveTrading.tsx
@@ -4,12 +4,8 @@ import MetricCard from '../components/ui/MetricCard';
 import LiveLog from '../components/ui/LiveLog';
 import { TrendingUp, DollarSign, Target, Activity } from 'lucide-react';
 import { useAppStore } from '../store/useAppStore';
+import { apiFetch } from '../api/client';
 
-const API_BASE_URL = '';
-const API_TOKEN =
-  import.meta.env.VITE_DASHBOARD_API_TOKEN ||
-  window.localStorage.getItem('DASHBOARD_API_TOKEN') ||
-  ''; // no hardcoded secret
 
 // CORRECTION: Types pour les données API
 interface InstanceStatus {
@@ -108,7 +104,7 @@ const LiveTrading: React.FC = () => {
         setError(null);
 
         // Récupère le statut global
-        const statusRes = await fetch(`${API_BASE_URL}/api/status`, { headers: { "Authorization": `Bearer ${API_TOKEN}` } });
+        const statusRes = await apiFetch(`/api/status`);
         if (!statusRes.ok) throw new Error(`API Error: ${statusRes.status}`);
         const statusData: GlobalStatus = await statusRes.json();
         setGlobalStatus(statusData);
@@ -116,14 +112,14 @@ const LiveTrading: React.FC = () => {
         setBotStatus(statusData.running ? 'ACTIVE' : 'INACTIVE');
 
         // Récupère les instances
-        const instancesRes = await fetch(`${API_BASE_URL}/api/instances`, { headers: { "Authorization": `Bearer ${API_TOKEN}` } });
+        const instancesRes = await apiFetch(`/api/instances`);
         if (!instancesRes.ok) throw new Error(`API Error: ${instancesRes.status}`);
         const instancesData: InstanceStatus[] = await instancesRes.json();
 
         // Récupère les positions de la première instance (s'il y en a une)
         if (instancesData.length > 0) {
           const firstInstanceId = instancesData[0].id;
-          const positionsRes = await fetch(`${API_BASE_URL}/api/instances/${firstInstanceId}/positions`, { headers: { "Authorization": `Bearer ${API_TOKEN}` } });
+          const positionsRes = await apiFetch(`/api/instances/${firstInstanceId}/positions`);
           if (positionsRes.ok) {
             const positionsData: PositionInfo[] = await positionsRes.json();
             setPositions(positionsData);
@@ -134,7 +130,7 @@ const LiveTrading: React.FC = () => {
           setPositions([]);
         }
 
-        const historyRes = await fetch(`${API_BASE_URL}/api/history?days=1`, { headers: { "Authorization": `Bearer ${API_TOKEN}` } });
+        const historyRes = await apiFetch(`/api/history?days=1`);
         if (historyRes.ok) {
           const historyData = await historyRes.json();
           const series: HistoryPoint[] = Array.isArray(historyData?.history) ? historyData.history : [];
@@ -151,10 +147,10 @@ const LiveTrading: React.FC = () => {
         }
 
         const [scalingRes, universeRes, opportunitiesRes, allocationRes] = await Promise.all([
-          fetch(`${API_BASE_URL}/api/scaling/status`, { headers: { "Authorization": `Bearer ${API_TOKEN}` } }),
-          fetch(`${API_BASE_URL}/api/universe/status`, { headers: { "Authorization": `Bearer ${API_TOKEN}` } }),
-          fetch(`${API_BASE_URL}/api/opportunities/top?limit=8`, { headers: { "Authorization": `Bearer ${API_TOKEN}` } }),
-          fetch(`${API_BASE_URL}/api/portfolio/allocation`, { headers: { "Authorization": `Bearer ${API_TOKEN}` } }),
+          apiFetch(`/api/scaling/status`),
+          apiFetch(`/api/universe/status`),
+          apiFetch(`/api/opportunities/top?limit=8`),
+          apiFetch(`/api/portfolio/allocation`),
         ]);
 
         if (scalingRes.ok) setScalingStatus(await scalingRes.json());

--- a/dashboard/src/pages/Performance.tsx
+++ b/dashboard/src/pages/Performance.tsx
@@ -3,9 +3,8 @@ import { AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContai
 import MetricCard from '../components/ui/MetricCard';
 import Tabs, { Tab } from '../components/ui/Tabs';
 import { Activity, TrendingUp, BarChart3, Wallet, Target, Layers, GraduationCap, RefreshCw, AlertTriangle, CheckCircle, XCircle, Wifi, WifiOff, Clock } from 'lucide-react';
+import { apiFetch } from '../api/client';
 
-const API_BASE_URL = '';
-const API_TOKEN = import.meta.env.VITE_DASHBOARD_API_TOKEN || window.localStorage.getItem('DASHBOARD_API_TOKEN') || '';// no hardcoded secret
 
 interface GlobalPerf {
   capital_total: number; capital_initial: number; profit_total: number;
@@ -45,11 +44,6 @@ const formatUptime = (seconds: number | null): string => {
   return `${h}h ${m}m`;
 };
 const fmt = (n: number, d=2) => n.toLocaleString('fr-FR', {minimumFractionDigits:d, maximumFractionDigits:d});
-interface BotStatus {
-  running: boolean; instance_count: number; total_capital: number;
-  total_profit: number; websocket_connected: boolean; uptime_seconds: number | null;
-  total_trades?: number;
-}
 const fmtEur = (n: number) => `${fmt(n)}€`;
 const pfColor = (pf: number) => pf>=2?'text-emerald-400':pf>=1.5?'text-green-400':pf>=1?'text-yellow-400':'text-red-400';
 const profitColor = (n: number) => n>=0?'text-emerald-400':'text-red-400';
@@ -58,11 +52,9 @@ const stratLabel = (s: string): string => {
   return m[s] || s;
 };
 
-async function apiFetch<T>(path: string): Promise<T|null> {
+async function apiFetchJson<T>(path: string): Promise<T|null> {
   try { 
-    const r = await fetch(`${API_BASE_URL}${path}`, { 
-      headers: { "Authorization": `Bearer ${API_TOKEN}` } 
-    }); 
+    const r = await apiFetch(path); 
     return r.ok ? await r.json() : null; 
   } catch { 
     return null; 
@@ -92,11 +84,11 @@ const Performance: React.FC = () => {
 
   const fetchAll = useCallback(async () => {
     const [g,p,pp,rb,bs] = await Promise.all([
-      apiFetch<GlobalPerf>('/api/performance/global'),
-      apiFetch<{pairs:PairPerf[]}>('/api/performance/by-pair'),
-      apiFetch<PaperSummary>('/api/paper-trading/summary'),
-      apiFetch<RebStatus>('/api/rebalance/status'),
-      apiFetch<BotStatus>('/api/status'),
+      apiFetchJson<GlobalPerf>('/api/performance/global'),
+      apiFetchJson<{pairs:PairPerf[]}>('/api/performance/by-pair'),
+      apiFetchJson<PaperSummary>('/api/paper-trading/summary'),
+      apiFetchJson<RebStatus>('/api/rebalance/status'),
+      apiFetchJson<BotStatus>('/api/status'),
     ]);
     if(g) setGlobalPerf(g); if(p) setPairPerfs(p.pairs);
     if(pp) setPaperSummary(pp); if(rb) setRebStatus(rb); if(bs) setBotStatus(bs);


### PR DESCRIPTION
### Motivation
- Supprimer l'accès direct à `window.localStorage.getItem('DASHBOARD_API_TOKEN')` et éviter la duplication d'ajout d'en-têtes d'authentification page par page.
- Préparer le dashboard pour supporter une authentification en mémoire ou via session backend HttpOnly/SameSite en centralisant la logique d'API.

### Description
- Ajout d'un client API partagé `dashboard/src/api/client.ts` exposant `apiFetch` et `apiAuth` qui gère un token en mémoire (initialisé depuis `VITE_DASHBOARD_API_TOKEN` si présent) et injecte automatiquement `Authorization` lorsqu'il existe.
- `apiFetch` envoie systématiquement `credentials: 'include'` pour permettre l'utilisation de sessions backend (cookies HttpOnly/SameSite) sans stocker le token dans le navigateur.
- Remplacement des lectures `localStorage.getItem('DASHBOARD_API_TOKEN')` et des appels `fetch` avec header Authorization dispersés par des appels à `apiFetch` dans les pages `Capital`, `Diagnostic`, `LiveTrading`, `Analytics`, `Backtest` et `Performance`.
- Dans `Performance`, ajout d'un petit wrapper `apiFetchJson` qui réutilise le client partagé pour retourner JSON et réduire la duplication d'appel/gestion d'erreur.

### Testing
- Exécution de la build avec `npm --prefix dashboard run build` a réussi (production build générée).
- Exécution des tests unitaires avec `npm --prefix dashboard run test` a réussi (tests Vitest exécutés, tous verts).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8ec522a0c832faea64063bfb86e10)