### PR TITLE
Add bounds-checked offset pagination to /api/trades

### DIFF
--- a/src/autobot/v2/api/dashboard.py
+++ b/src/autobot/v2/api/dashboard.py
@@ -10,7 +10,7 @@ import threading
 import inspect
 from typing import Dict, List, Optional, Any
 from datetime import datetime, timezone
-from fastapi import FastAPI, HTTPException, Request, Depends
+from fastapi import FastAPI, HTTPException, Request, Depends, Query
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from pydantic import BaseModel
@@ -948,7 +948,12 @@ async def get_capital_detail(request: Request, authorized: bool = Depends(verify
 
 
 @app.get("/api/trades")
-async def get_trades(request: Request, authorized: bool = Depends(verify_token), limit: int = 50):
+async def get_trades(
+    request: Request,
+    authorized: bool = Depends(verify_token),
+    limit: int = Query(default=50, ge=1, le=200),
+    offset: int = Query(default=0, ge=0),
+):
     """Liste des trades exécutés"""
     orchestrator = request.app.state.orchestrator
     if not orchestrator:
@@ -977,9 +982,20 @@ async def get_trades(request: Request, authorized: bool = Depends(verify_token),
 
         trades.sort(key=lambda x: x['timestamp'], reverse=True)
 
+        total_count = len(trades)
+        paginated_trades = trades[offset:offset + limit]
+
         return {
-            "count": len(trades),
-            "trades": trades[:limit]
+            "count": total_count,
+            "pagination": {
+                "limit": limit,
+                "offset": offset,
+                "returned": len(paginated_trades),
+                "total": total_count,
+                "has_more": (offset + limit) < total_count,
+                "next_offset": (offset + limit) if (offset + limit) < total_count else None,
+            },
+            "trades": paginated_trades
         }
     except Exception:
         logger.exception("Erreur récupération trades")


### PR DESCRIPTION
### Motivation
- Limiter la taille des réponses et éviter les transferts massifs en bornant `limit` et en ajoutant de la pagination.
- Fournir des métadonnées de pagination pour que le client puisse itérer sans récupérer l’intégralité de l’historique.

### Description
- Import de `Query` et modification de la signature de `get_trades` pour utiliser `limit: Query(default=50, ge=1, le=200)` et `offset: Query(default=0, ge=0)`.
- Conserver le tri des trades par `timestamp` puis appliquer une pagination offset via `trades[offset:offset+limit]`.
- Ajouter un objet `pagination` dans la réponse contenant `limit`, `offset`, `returned`, `total`, `has_more` et `next_offset`, tout en conservant le champ `count` et la liste `trades`.

### Testing
- Exécution de `python -m py_compile src/autobot/v2/api/dashboard.py` qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8ec3a3f3c832f96c52cc14886a4b3)