### PR TITLE
Implement hi/lo nonce reservation and async local nonce consumption

### DIFF
--- a/src/autobot/v2/nonce_manager.py
+++ b/src/autobot/v2/nonce_manager.py
@@ -31,8 +31,20 @@ class NonceManager:
             conn.commit()
 
     def next_nonce(self, api_key_id: str) -> int:
+        low, _high = self.reserve_range(api_key_id, block_size=1)
+        return int(low)
+
+    def reserve_range(self, api_key_id: str, block_size: int = 64) -> tuple[int, int]:
+        """
+        Reserve a contiguous nonce range in a single durable write.
+
+        Returns:
+            (low, high) inclusive range.
+        """
         if not api_key_id:
             raise ValueError("api_key_id is required")
+        if block_size <= 0:
+            raise ValueError("block_size must be > 0")
         now_ms = int(time.time() * 1000)
         with self._lock, sqlite3.connect(str(self.db_path), timeout=5.0) as conn:
             conn.execute("PRAGMA busy_timeout=5000")
@@ -42,17 +54,18 @@ class NonceManager:
                 (api_key_id,),
             ).fetchone()
             if row:
-                next_value = max(int(row[0]) + 1, now_ms)
+                low = max(int(row[0]) + 1, now_ms)
+                high = low + block_size - 1
                 conn.execute(
                     "UPDATE nonce_state SET last_nonce = ?, updated_at = datetime('now') WHERE api_key_id = ?",
-                    (next_value, api_key_id),
+                    (high, api_key_id),
                 )
             else:
-                next_value = now_ms
+                low = now_ms
+                high = low + block_size - 1
                 conn.execute(
                     "INSERT INTO nonce_state (api_key_id, last_nonce) VALUES (?, ?)",
-                    (api_key_id, next_value),
+                    (api_key_id, high),
                 )
             conn.commit()
-            return int(next_value)
-
+            return int(low), int(high)

--- a/src/autobot/v2/order_executor_async.py
+++ b/src/autobot/v2/order_executor_async.py
@@ -74,6 +74,10 @@ class OrderExecutorAsync:
 
         # Centralized nonce manager (cross-worker/process monotonicity)
         self._nonce_manager: NonceManager = nonce_manager or NonceManager()
+        self._nonce_cache_lock = asyncio.Lock()
+        self._nonce_block_size: int = 64
+        self._nonce_next: Optional[int] = None
+        self._nonce_high: Optional[int] = None
 
         # Rate limiting
         self._last_call_time: float = 0
@@ -128,7 +132,7 @@ class OrderExecutorAsync:
 
         # Centralized monotonic nonce generation per API key fingerprint
         api_key_id = hashlib.sha256((self._api_key or "none").encode("utf-8")).hexdigest()[:16]
-        nonce = self._nonce_manager.next_nonce(api_key_id)
+        nonce = await self._next_nonce(api_key_id)
         params["nonce"] = str(int(nonce))
         sig = _kraken_signature(urlpath, params, self._api_secret)
 
@@ -140,6 +144,30 @@ class OrderExecutorAsync:
         session = await self._get_session()
         async with session.post(url, data=params, headers=headers) as resp:
             return await resp.json()
+
+    async def _next_nonce(self, api_key_id: str) -> int:
+        """
+        Consume a locally cached hi/lo nonce range.
+
+        A fresh range is reserved durably in SQLite only when local cache is exhausted.
+        """
+        async with self._nonce_cache_lock:
+            if (
+                self._nonce_next is None
+                or self._nonce_high is None
+                or self._nonce_next > self._nonce_high
+            ):
+                low, high = await asyncio.to_thread(
+                    self._nonce_manager.reserve_range,
+                    api_key_id,
+                    self._nonce_block_size,
+                )
+                self._nonce_next = int(low)
+                self._nonce_high = int(high)
+
+            nonce = int(self._nonce_next)
+            self._nonce_next += 1
+            return nonce
 
     # ------------------------------------------------------------------
     # Rate limiting

--- a/tests/test_nonce_safety.py
+++ b/tests/test_nonce_safety.py
@@ -1,6 +1,7 @@
 import pytest
 
 import asyncio
+import multiprocessing as mp
 from concurrent.futures import ThreadPoolExecutor
 
 from autobot.v2.order_executor_async import OrderExecutorAsync
@@ -22,6 +23,54 @@ def test_nonce_generator_monotonic_under_concurrency(tmp_path):
     # Concurrency can reorder return completion, but generated values must be strictly increasing globally.
     sorted_values = sorted(values)
     assert all(sorted_values[i] < sorted_values[i + 1] for i in range(len(sorted_values) - 1))
+
+
+def _reserve_in_process(db_path: str, api_key_id: str, count: int) -> list[int]:
+    nm = NonceManager(db_path)
+    return [nm.next_nonce(api_key_id) for _ in range(count)]
+
+
+def test_nonce_generator_monotonic_under_multi_process(tmp_path):
+    db_path = str(tmp_path / "nonce-multiprocess.db")
+    workers = 4
+    per_worker = 80
+
+    with mp.Pool(processes=workers) as pool:
+        batches = pool.starmap(
+            _reserve_in_process,
+            [(db_path, "api-key-1", per_worker) for _ in range(workers)],
+        )
+
+    values = [nonce for batch in batches for nonce in batch]
+    assert len(values) == workers * per_worker
+    assert len(values) == len(set(values))
+    sorted_values = sorted(values)
+    assert all(sorted_values[i] < sorted_values[i + 1] for i in range(len(sorted_values) - 1))
+
+
+def test_order_executor_uses_reserved_local_nonce_range():
+    async def _run():
+        class FakeNonceManager:
+            def __init__(self) -> None:
+                self.calls = 0
+
+            def reserve_range(self, _api_key_id: str, block_size: int = 64):
+                start = self.calls * block_size + 1_000_000
+                self.calls += 1
+                return start, start + block_size - 1
+
+            def next_nonce(self, _api_key_id: str) -> int:
+                raise AssertionError("next_nonce should not be used by async executor")
+
+        fake = FakeNonceManager()
+        ex = OrderExecutorAsync(api_key="k", api_secret="c2VjcmV0", nonce_manager=fake)
+
+        values = await asyncio.gather(*[ex._next_nonce("api-key-1") for _ in range(130)])
+        assert values == sorted(values)
+        assert len(values) == len(set(values))
+        assert fake.calls == 3  # 130 nonces => 3 reserves with block size 64
+
+    asyncio.run(_run())
 
 
 def test_repeated_invalid_nonce_triggers_circuit_breaker(monkeypatch):


### PR DESCRIPTION
### Motivation

- Réduire la fréquence d'écritures durables sur le magasin de nonces en réservant des plages contiguës (hi/lo) et amortir la persistance pour l'exécuteur asynchrone.
- Garantir la monotonie globale des nonces partagés entre processus/threads via une réservation atomique en SQLite.
- Permettre à `OrderExecutorAsync` de produire des nonces sans bloquer la boucle `asyncio` et sans invoquer SQLite à chaque appel.

### Description

- Ajout de `NonceManager.reserve_range(api_key_id, block_size)` qui réserve atomiquement une plage contiguë et persiste uniquement le watermark haut dans SQLite, avec validation de `api_key_id` et `block_size`.
- Conservation de la compatibilité : `NonceManager.next_nonce()` délègue maintenant à `reserve_range(..., block_size=1)` pour le comportement d'origine.
- Adaptation de `OrderExecutorAsync` : ajout d'un cache local hi/lo (`_nonce_next`, `_nonce_high`) protégé par `asyncio.Lock` (`_nonce_cache_lock`), et nouvelle méthode asynchrone `_next_nonce(api_key_id)` qui réserve une plage via `asyncio.to_thread(self._nonce_manager.reserve_range, ...)` uniquement quand le cache est épuisé.
- Tests étendus dans `tests/test_nonce_safety.py` : ajout d'un test multi-process pour la monotonie/unicité et d'un test vérifiant l'amortissement (réservations minimisées) de l'exécuteur asynchrone.

### Testing

- J'ai d'abord tenté `pytest -q tests/test_nonce_safety.py` mais la collecte a échoué localement par `ModuleNotFoundError` car `PYTHONPATH` n'était pas positionné.
- Les tests ont été exécutés avec `PYTHONPATH=src pytest -q tests/test_nonce_safety.py` et tous les tests ciblés ont réussi (`4 passed`).
- Les cas couverts automatiquement sont : génération monotone sous concurrence thread, génération monotone sous multi-process, amortissement de réservations par `OrderExecutorAsync`, et le test existant du déclenchement du circuit breaker sur nonces invalides.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8ec23e028832f947171d11aeaaba3)