### PR TITLE
Use safe fallback for low capital, validate risk tiers, and add unit tests

### DIFF
--- a/src/autobot/v2/risk_manager.py
+++ b/src/autobot/v2/risk_manager.py
@@ -34,7 +34,7 @@ class RiskManager:
     DEFAULT_CONFIGS = [
         RiskConfig(
             capital_min=100,
-            capital_max=499,
+            capital_max=500,
             stop_loss_pct=-0.25,
             take_profit_pct=0.40,
             max_positions=5,
@@ -43,7 +43,7 @@ class RiskManager:
         ),
         RiskConfig(
             capital_min=500,
-            capital_max=999,
+            capital_max=1000,
             stop_loss_pct=-0.20,
             take_profit_pct=0.30,
             max_positions=8,
@@ -52,7 +52,7 @@ class RiskManager:
         ),
         RiskConfig(
             capital_min=1000,
-            capital_max=1999,
+            capital_max=2000,
             stop_loss_pct=-0.15,
             take_profit_pct=0.25,
             max_positions=10,
@@ -61,7 +61,7 @@ class RiskManager:
         ),
         RiskConfig(
             capital_min=2000,
-            capital_max=4999,
+            capital_max=5000,
             stop_loss_pct=-0.12,
             take_profit_pct=0.22,
             max_positions=12,
@@ -84,19 +84,48 @@ class RiskManager:
 
     def __init__(self, configs: Optional[list] = None, orchestrator: Optional[object] = None):
         self.configs = configs or self.DEFAULT_CONFIGS
+        self._validate_configs()
         self._on_sl_triggered: Optional[Callable] = None
         self._on_tp_triggered: Optional[Callable] = None
         self._orchestrator = orchestrator  # Référence orchestrator pour disjoncteur
         
         logger.info("🛡️ RiskManager initialisé")
+
+    def _validate_configs(self) -> None:
+        """Valide la cohérence des paliers (triés, continus, non chevauchants)."""
+        if not self.configs:
+            raise ValueError("RiskManager requires at least one risk config")
+
+        for i, config in enumerate(self.configs):
+            if config.capital_min >= config.capital_max:
+                raise ValueError(
+                    f"Invalid risk config range at index {i}: "
+                    f"[{config.capital_min}, {config.capital_max})"
+                )
+
+            if i == 0:
+                continue
+
+            prev = self.configs[i - 1]
+            if config.capital_min < prev.capital_min:
+                raise ValueError("Risk config tiers must be sorted by capital_min")
+
+            if config.capital_min != prev.capital_max:
+                raise ValueError(
+                    "Risk config tiers must be continuous and non-overlapping: "
+                    f"expected capital_min={prev.capital_max}, got {config.capital_min}"
+                )
     
     def get_config_for_capital(self, capital: float) -> RiskConfig:
         """Retourne la configuration adaptée au capital"""
+        if capital < self.configs[0].capital_min:
+            return self.configs[0]
+
         for config in self.configs:
             if config.capital_min <= capital < config.capital_max:
                 return config
         
-        # Fallback sur dernière config
+        # Fallback sur dernière config (capitaux au-dessus du maximum)
         return self.configs[-1]
     
     def calculate_sl_price(self, entry_price: float, capital: float, side: str = 'long') -> float:

--- a/src/autobot/v2/tests/test_risk_manager.py
+++ b/src/autobot/v2/tests/test_risk_manager.py
@@ -1,0 +1,60 @@
+import pytest
+
+from autobot.v2.risk_manager import RiskConfig, RiskManager
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_get_config_for_capital_uses_first_tier_for_capital_below_minimum():
+    manager = RiskManager()
+
+    config = manager.get_config_for_capital(50)
+
+    assert config == manager.configs[0]
+
+
+def test_get_config_for_capital_handles_tier_boundaries():
+    manager = RiskManager()
+
+    assert manager.get_config_for_capital(100) == manager.configs[0]
+    assert manager.get_config_for_capital(500) == manager.configs[1]
+    assert manager.get_config_for_capital(1000) == manager.configs[2]
+    assert manager.get_config_for_capital(2000) == manager.configs[3]
+    assert manager.get_config_for_capital(5000) == manager.configs[4]
+
+
+def test_get_config_for_capital_above_max_falls_back_to_last_tier():
+    manager = RiskManager(
+        configs=[
+            RiskConfig(100, 200, -0.20, 0.30, 2, 1, "tier-1"),
+            RiskConfig(200, 300, -0.15, 0.25, 3, 2, "tier-2"),
+        ]
+    )
+
+    assert manager.get_config_for_capital(10_000) == manager.configs[-1]
+
+
+@pytest.mark.parametrize(
+    "configs",
+    [
+        # Non triés
+        [
+            RiskConfig(200, 300, -0.15, 0.25, 3, 2, "tier-2"),
+            RiskConfig(100, 200, -0.20, 0.30, 2, 1, "tier-1"),
+        ],
+        # Trou entre paliers
+        [
+            RiskConfig(100, 200, -0.20, 0.30, 2, 1, "tier-1"),
+            RiskConfig(250, 300, -0.15, 0.25, 3, 2, "tier-2"),
+        ],
+        # Chevauchement
+        [
+            RiskConfig(100, 250, -0.20, 0.30, 2, 1, "tier-1"),
+            RiskConfig(200, 300, -0.15, 0.25, 3, 2, "tier-2"),
+        ],
+    ],
+)
+def test_risk_manager_validates_tier_consistency_at_startup(configs):
+    with pytest.raises(ValueError):
+        RiskManager(configs=configs)


### PR DESCRIPTION
### Motivation
- Assurer un comportement sûr quand `capital` est inférieur au minimum configuré en évitant le fallback dangereux sur le dernier palier. 
- Empêcher configs incohérentes (non triées, trous ou chevauchements) qui pouvaient provoquer des comportements imprévisibles à l'exécution. 
- Couvrir ces cas par des tests unitaires pour garantir régression et robustesse du mapping capital → configuration. 

### Description
- Remplacé le fallback pour `capital < min` dans `RiskManager.get_config_for_capital` pour retourner le premier palier via `self.configs[0]` au lieu de `self.configs[-1]`. 
- Ajouté la méthode `_validate_configs` appelée dans `__init__` pour valider que la liste `configs` n'est pas vide, que chaque `capital_min < capital_max`, que les paliers sont triés par `capital_min` et qu'ils sont continus/non-chevauchants (attente `config.capital_min == prev.capital_max`). 
- Ajusté les bornes dans `DEFAULT_CONFIGS` pour des intervalles semi-ouverts continus (`capital_max` modifié de 499→500, 999→1000, 1999→2000, 4999→5000) afin d'éliminer les trous aux frontières avec la logique `[min, max)`. 
- Ajouté `src/autobot/v2/tests/test_risk_manager.py` avec tests unitaires pour les cas `capital < min`, `capital == bornes`, `capital > max`, et scénarios invalides (non triés, trou, chevauchement) rejetés à l'initialisation. 

### Testing
- Lancement local des tests ciblés avec `PYTHONPATH=src pytest -q src/autobot/v2/tests/test_risk_manager.py` a réussi avec `6 passed`. 
- Un premier lancement sans `PYTHONPATH` échouait en collecte à cause d'un import path manquant dans l'environnement, ce qui a été résolu en exécutant les tests via `PYTHONPATH=src`. 
- Les modifications sont couvertes par les nouveaux tests ajoutés dans `src/autobot/v2/tests/test_risk_manager.py` qui valident les comportements et les rejets de configs invalides.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8ebea7328832fb9e32dbbd908a694)