### PR TITLE
Refactor OrchestratorAsync into dedicated safety and reporting services

### DIFF
--- a/src/autobot/v2/orchestrator_async.py
+++ b/src/autobot/v2/orchestrator_async.py
@@ -19,7 +19,7 @@ import asyncio
 import logging
 import os
 import uuid
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timezone
 from time import perf_counter
 from typing import Any, Callable, Coroutine, Dict, List, Optional
 
@@ -140,8 +140,10 @@ from .orchestrator_services import (
     InstanceActivationService,
     InstanceLifecycleService,
     PortfolioAllocationService,
+    ReportingService,
     ScalabilityGuardService,
     ScalabilityMetrics,
+    SafetyService,
     journal_symbol_cap,
 )
 from .decision_journal import (
@@ -500,6 +502,7 @@ class OrchestratorAsync:
             )
         self.lifecycle_service = InstanceLifecycleService()
         self.background_tasks = BackgroundTasksService()
+        self.reporting_service = ReportingService(self.daily_reporter)
         self.decision_journal_service = DecisionJournalService(
             journal=self.decision_journal,
             enabled=self._decision_journal_enabled,
@@ -509,6 +512,12 @@ class OrchestratorAsync:
         self.portfolio_allocation_service = PortfolioAllocationService(
             self.portfolio_allocator,
             self.risk_cluster_manager,
+        )
+        self.safety_service = SafetyService(
+            safety_guard=self.safety_guard,
+            robustness_guard=self.robustness_guard,
+            hardening_flags=self.hardening_flags,
+            reset_flag_reader=lambda: _env_bool("SAFETY_EMERGENCY_RESET", False),
         )
 
         # Market selector (reuse sync version)
@@ -1533,35 +1542,18 @@ class OrchestratorAsync:
                     self._on_alert("LOW_HEALTH_SCORE", {"score": health})
 
     def _activate_emergency_mode(self, reason: str) -> None:
-        if self.safety_guard.emergency_mode:
-            return
-        self.safety_guard.emergency_mode = True
-        self.robustness_guard.set_emergency_mode(True)
-        self.hardening_flags["enable_validation_guard"] = False
-        self.hardening_flags["enable_sentiment"] = False
-        self.hardening_flags["enable_ml"] = False
-        self.hardening_flags["enable_xgboost"] = False
-        self.hardening_flags["enable_onchain"] = False
-        logger.error("🚨 SAFETY EMERGENCY MODE enabled: %s", reason)
+        self.safety_service.activate_emergency_mode(reason, logger)
 
     def _reset_emergency_mode(self) -> None:
-        self.safety_guard.reset_emergency()
-        self.robustness_guard.set_emergency_mode(False)
+        self.safety_service.reset_emergency_mode()
 
     async def _check_cycle_health(self) -> None:
-        """Vérifie la santé du cycle toutes les 5 minutes."""
-        while self.running:
-            try:
-                await asyncio.sleep(300)
-                cycle_ms = float(self._loop_metrics.get("process_cycle_ms", 0.0))
-                if not self.safety_guard.check_performance_budget(cycle_ms):
-                    self._activate_emergency_mode("cycle health monitor")
-                if _env_bool("SAFETY_EMERGENCY_RESET", False):
-                    self._reset_emergency_mode()
-            except asyncio.CancelledError:
-                break
-            except Exception as exc:
-                logger.warning("Cycle health check erreur (isolée): %s", exc)
+        await self.safety_service.monitor_cycle_health(
+            running=lambda: self.running,
+            loop_metrics=self._loop_metrics,
+            on_activate=self._activate_emergency_mode,
+            logger=logger,
+        )
 
     async def _run_black_swan_guard(self, instance: TradingInstanceAsync) -> bool:
         """
@@ -2374,34 +2366,10 @@ class OrchestratorAsync:
         await self.emergency_stop_all()
 
     async def _daily_report_loop(self) -> None:
-        """
-        Génère un rapport quotidien à minuit UTC.
-        """
-        while self.running:
-            try:
-                now = datetime.now(timezone.utc)
-                next_day = (now + timedelta(days=1)).replace(
-                    hour=0,
-                    minute=0,
-                    second=0,
-                    microsecond=0,
-                )
-                wait_seconds = max((next_day - now).total_seconds(), 1.0)
-                await asyncio.sleep(wait_seconds)
-                try:
-                    report = self.daily_reporter.generate_report()
-                    logger.info(
-                        "🗓️ Daily report généré: date=%s trades=%s",
-                        report.get("date"),
-                        report.get("total_trades"),
-                    )
-                except Exception as exc:
-                    logger.warning("Daily report génération erreur (isolée): %s", exc)
-            except asyncio.CancelledError:
-                break
-            except Exception as exc:
-                logger.warning("Daily report loop erreur (isolée): %s", exc)
-                await asyncio.sleep(60)
+        await self.reporting_service.run_daily_report_loop(
+            running=lambda: self.running,
+            logger=logger,
+        )
 
     # ------------------------------------------------------------------
     # Lifecycle

--- a/src/autobot/v2/orchestrator_services.py
+++ b/src/autobot/v2/orchestrator_services.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+from datetime import datetime, timedelta, timezone
 from dataclasses import dataclass
 from typing import Any, Awaitable, Callable, Dict, Iterable, List, Optional, Protocol, Sequence
 
@@ -267,6 +268,97 @@ class BackgroundTasksService:
             except asyncio.CancelledError:
                 pass
             self.tasks.pop(name, None)
+
+
+class SafetyService:
+    def __init__(
+        self,
+        *,
+        safety_guard: Any,
+        robustness_guard: Any,
+        hardening_flags: Dict[str, bool],
+        reset_flag_reader: Callable[[], bool],
+    ) -> None:
+        self.safety_guard = safety_guard
+        self.robustness_guard = robustness_guard
+        self.hardening_flags = hardening_flags
+        self.reset_flag_reader = reset_flag_reader
+
+    def activate_emergency_mode(self, reason: str, logger: Any) -> bool:
+        if self.safety_guard.emergency_mode:
+            return False
+        self.safety_guard.emergency_mode = True
+        self.robustness_guard.set_emergency_mode(True)
+        self.hardening_flags["enable_validation_guard"] = False
+        self.hardening_flags["enable_sentiment"] = False
+        self.hardening_flags["enable_ml"] = False
+        self.hardening_flags["enable_xgboost"] = False
+        self.hardening_flags["enable_onchain"] = False
+        logger.error("🚨 SAFETY EMERGENCY MODE enabled: %s", reason)
+        return True
+
+    def reset_emergency_mode(self) -> None:
+        self.safety_guard.reset_emergency()
+        self.robustness_guard.set_emergency_mode(False)
+
+    async def monitor_cycle_health(
+        self,
+        *,
+        running: Callable[[], bool],
+        loop_metrics: Dict[str, float],
+        on_activate: Callable[[str], None],
+        logger: Any,
+        interval_seconds: float = 300.0,
+    ) -> None:
+        while running():
+            try:
+                await asyncio.sleep(interval_seconds)
+                cycle_ms = float(loop_metrics.get("process_cycle_ms", 0.0))
+                if not self.safety_guard.check_performance_budget(cycle_ms):
+                    on_activate("cycle health monitor")
+                if self.reset_flag_reader():
+                    self.reset_emergency_mode()
+            except asyncio.CancelledError:
+                break
+            except Exception as exc:
+                logger.warning("Cycle health check erreur (isolée): %s", exc)
+
+
+class ReportingService:
+    def __init__(self, reporter: Any) -> None:
+        self.reporter = reporter
+
+    async def run_daily_report_loop(
+        self,
+        *,
+        running: Callable[[], bool],
+        logger: Any,
+    ) -> None:
+        while running():
+            try:
+                now = datetime.now(timezone.utc)
+                next_day = (now + timedelta(days=1)).replace(
+                    hour=0,
+                    minute=0,
+                    second=0,
+                    microsecond=0,
+                )
+                wait_seconds = max((next_day - now).total_seconds(), 1.0)
+                await asyncio.sleep(wait_seconds)
+                try:
+                    report = self.reporter.generate_report()
+                    logger.info(
+                        "🗓️ Daily report généré: date=%s trades=%s",
+                        report.get("date"),
+                        report.get("total_trades"),
+                    )
+                except Exception as exc:
+                    logger.warning("Daily report génération erreur (isolée): %s", exc)
+            except asyncio.CancelledError:
+                break
+            except Exception as exc:
+                logger.warning("Daily report loop erreur (isolée): %s", exc)
+                await asyncio.sleep(60)
 
 
 def journal_symbol_cap() -> int:

--- a/tests/test_orchestrator_services_safety_reporting.py
+++ b/tests/test_orchestrator_services_safety_reporting.py
@@ -1,0 +1,117 @@
+import asyncio
+
+import pytest
+
+from autobot.v2.orchestrator_services import ReportingService, SafetyService
+
+
+pytestmark = pytest.mark.integration
+
+
+class _Logger:
+    def __init__(self):
+        self.infos = []
+        self.errors = []
+        self.warnings = []
+
+    def info(self, msg, *args):
+        self.infos.append(msg % args if args else msg)
+
+    def error(self, msg, *args):
+        self.errors.append(msg % args if args else msg)
+
+    def warning(self, msg, *args):
+        self.warnings.append(msg % args if args else msg)
+
+
+class _SafetyGuard:
+    def __init__(self):
+        self.emergency_mode = False
+        self.reset_calls = 0
+
+    def check_performance_budget(self, _cycle_ms):
+        return False
+
+    def reset_emergency(self):
+        self.reset_calls += 1
+        self.emergency_mode = False
+
+
+class _RobustnessGuard:
+    def __init__(self):
+        self.values = []
+
+    def set_emergency_mode(self, value):
+        self.values.append(bool(value))
+
+
+class _Reporter:
+    def __init__(self):
+        self.calls = 0
+
+    def generate_report(self):
+        self.calls += 1
+        return {"date": "2026-04-22", "total_trades": 3}
+
+
+@pytest.mark.asyncio
+async def test_safety_service_emergency_and_monitor_cycle_health():
+    logger = _Logger()
+    safety_guard = _SafetyGuard()
+    robustness_guard = _RobustnessGuard()
+    hardening_flags = {
+        "enable_validation_guard": True,
+        "enable_sentiment": True,
+        "enable_ml": True,
+        "enable_xgboost": True,
+        "enable_onchain": True,
+    }
+    service = SafetyService(
+        safety_guard=safety_guard,
+        robustness_guard=robustness_guard,
+        hardening_flags=hardening_flags,
+        reset_flag_reader=lambda: False,
+    )
+
+    assert service.activate_emergency_mode("budget", logger) is True
+    assert safety_guard.emergency_mode is True
+    assert robustness_guard.values[-1] is True
+    assert hardening_flags["enable_ml"] is False
+
+    running = True
+    activated = asyncio.Event()
+
+    def _on_activate(_reason):
+        nonlocal running
+        running = False
+        activated.set()
+
+    await service.monitor_cycle_health(
+        running=lambda: running,
+        loop_metrics={"process_cycle_ms": 1000.0},
+        on_activate=_on_activate,
+        logger=logger,
+        interval_seconds=0.01,
+    )
+
+    assert activated.is_set()
+
+
+@pytest.mark.asyncio
+async def test_reporting_service_daily_loop_calls_report(monkeypatch):
+    logger = _Logger()
+    reporter = _Reporter()
+    service = ReportingService(reporter)
+
+    running = True
+
+    async def _fake_sleep(_seconds):
+        nonlocal running
+        running = False
+
+    monkeypatch.setattr("autobot.v2.orchestrator_services.asyncio.sleep", _fake_sleep)
+
+    await service.run_daily_report_loop(running=lambda: running, logger=logger)
+
+    assert reporter.calls == 1
+    assert any("Daily report généré" in line for line in logger.infos)


### PR DESCRIPTION
### Motivation
- Reduce responsibility surface of `OrchestratorAsync` by moving safety and reporting logic into small, testable service classes so the orchestrator acts as a thin, composable façade.

### Description
- Add `SafetyService` to `src/autobot/v2/orchestrator_services.py` to centralize emergency-mode activation/reset and cycle-health monitoring logic.
- Add `ReportingService` to `src/autobot/v2/orchestrator_services.py` to encapsulate the daily report loop and its error handling.
- Wire `OrchestratorAsync` (`src/autobot/v2/orchestrator_async.py`) to compose and delegate to `SafetyService` and `ReportingService`, replacing inline implementations of `_activate_emergency_mode`, `_reset_emergency_mode`, `_check_cycle_health`, and `_daily_report_loop` with service calls.
- Add integration tests `tests/test_orchestrator_services_safety_reporting.py` to validate `SafetyService` emergency activation and cycle-health monitor and `ReportingService` daily loop behavior, and update imports accordingly.

### Testing
- Running `pytest -q tests/test_orchestrator_services_background_tasks.py tests/test_orchestrator_services_portfolio_lifecycle.py tests/test_orchestrator_services_safety_reporting.py tests/test_orchestrator_async_wiring.py` without `PYTHONPATH=src` failed during collection due to import paths (`ModuleNotFoundError: autobot`).
- Running `PYTHONPATH=src pytest -q tests/test_orchestrator_services_background_tasks.py tests/test_orchestrator_services_portfolio_lifecycle.py tests/test_orchestrator_services_safety_reporting.py tests/test_orchestrator_async_wiring.py` completed successfully with `6 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8f25172b0832fbb76238c963aba3c)