### PR TITLE
Harden Docker health checks by removing insecure `curl -k`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ FROM python:3.11-slim
 RUN apt-get update && apt-get install -y \
     gcc \
     curl \
+    ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
 # Créer utilisateur non-root
@@ -49,7 +50,11 @@ RUN chown -R appuser:appuser /app
 EXPOSE 8080
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=15s --retries=3 \
-    CMD curl -fk https://localhost:8080/health || exit 1
+    CMD sh -c 'if [ "${HEALTHCHECK_MODE:-internal_http}" = "tls" ]; then \
+      curl --fail --silent --show-error --cacert "${HEALTHCHECK_CA_CERT:-/app/certs/ca.crt}" https://localhost:8080/health >/dev/null; \
+    else \
+      curl --fail --silent --show-error http://127.0.0.1:8080/health >/dev/null; \
+    fi' || exit 1
 
 USER appuser
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,20 @@ Detailed guide: `docs/PAPER_TRADING_OPERATIONS.md`.
 ## Mode live
 Voir `docs/LIVE_PROMOTION_GATES.md`, `SECURITY.md`, `RUNBOOK.md`.
 
+## Healthcheck Docker (TLS vs endpoint interne)
+Le conteneur supporte **2 modes explicites** pour `/health`:
+
+| Contexte | Mode recommandé | Configuration | Comportement |
+|---|---|---|---|
+| Local/dev/paper sur réseau Docker privé | `internal_http` (défaut) | `HEALTHCHECK_MODE=internal_http` | Le healthcheck interroge `http://127.0.0.1:8080/health` (loopback interne au conteneur, sans TLS). |
+| Production avec terminaison TLS dans l'app | `tls` | `HEALTHCHECK_MODE=tls` + `HEALTHCHECK_CA_CERT=/app/certs/ca.crt` | Le healthcheck interroge `https://localhost:8080/health` avec validation CA stricte via `--cacert` (pas de `-k`). |
+
+Exemple production:
+```bash
+HEALTHCHECK_MODE=tls
+HEALTHCHECK_CA_CERT=/app/certs/ca.crt
+```
+
 ## Contribution policy
 - Do not commit build outputs (`dashboard/dist/`) or dependencies (`dashboard/node_modules/`).
 - Frontend artifacts must be generated during CI/CD builds (GitHub Actions/Netlify), not versioned in Git.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,11 @@ services:
       - DASHBOARD_API_TOKEN=${DASHBOARD_API_TOKEN}
       - DASHBOARD_SSL_CERT=/app/certs/server.crt
       - DASHBOARD_SSL_KEY=/app/certs/server.key
+      # Healthcheck mode:
+      # - internal_http (default): probe locale en HTTP via loopback (réseau conteneur local uniquement)
+      # - tls: probe HTTPS avec validation stricte d'un certificat CA de confiance
+      - HEALTHCHECK_MODE=${HEALTHCHECK_MODE:-internal_http}
+      - HEALTHCHECK_CA_CERT=${HEALTHCHECK_CA_CERT:-/app/certs/ca.crt}
       - INITIAL_CAPITAL=${INITIAL_CAPITAL:-100}
       - MAX_INSTANCES=${MAX_INSTANCES:-10}
       - PAPER_TRADING=${PAPER_TRADING:-true}
@@ -60,7 +65,7 @@ services:
     
     # Health check
     healthcheck:
-      test: ["CMD", "curl", "-f", "https://localhost:8080/health", "-k"]
+      test: ["CMD-SHELL", "if [ \"$$HEALTHCHECK_MODE\" = \"tls\" ]; then curl --fail --silent --show-error --cacert \"$$HEALTHCHECK_CA_CERT\" https://localhost:8080/health >/dev/null; else curl --fail --silent --show-error http://127.0.0.1:8080/health >/dev/null; fi"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
### Motivation
- Replace an insecure health-check that used `curl -k` (skips TLS verification) with a secure, environment-appropriate probe to avoid silent MITM or certificate bypass in production.
- Allow running a safe loopback HTTP probe for local/dev/docker-internal usage while supporting strict CA-validated TLS probes for environments where the app terminates TLS.

### Description
- Replaced the image `HEALTHCHECK` in `Dockerfile` to support two modes via `HEALTHCHECK_MODE`: `internal_http` (default) that probes `http://127.0.0.1:8080/health`, and `tls` that probes `https://localhost:8080/health` with CA validation using `--cacert`.
- Added `ca-certificates` to the image packages to enable certificate validation in TLS mode.
- Updated `docker-compose.yml` to expose `HEALTHCHECK_MODE` and `HEALTHCHECK_CA_CERT` environment variables, replaced the compose healthcheck command with a conditional `CMD-SHELL` that respects the selected mode, and added inline documentation describing the modes.
- Documented the two healthcheck modes and recommended environment usage in `README.md` with an example `HEALTHCHECK_MODE=tls` configuration.

### Testing
- Verified no remaining insecure `curl -k` usage by searching the repository with `rg` and inspecting the modified files with `nl`/`sed` (search returned no matches for `-k`).
- Attempted to validate compose configuration with `docker compose config` but the Docker CLI was not available in the execution environment (`docker: command not found`).
- Confirmed the patched files (`Dockerfile`, `docker-compose.yml`, `README.md`) contain the conditional healthcheck logic and the new environment variables by viewing the updated file contents.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8f24f37bc832f8939601ab15fdbda)