### PR TITLE
Normalize diagnostic check statuses and add overall aggregation tests

### DIFF
--- a/src/autobot/v2/diagnostic_manager.py
+++ b/src/autobot/v2/diagnostic_manager.py
@@ -124,9 +124,10 @@ class DiagnosticManager:
         ]
         
         for name, status in all_checks:
-            if status.get("status") == "error":
+            normalized_status = self._normalize_check_status(status.get("status"))
+            if normalized_status == "critical":
                 issues.append(f"{name}: {status.get('error', 'Erreur inconnue')}")
-            elif status.get("status") == "warning":
+            elif normalized_status == "warning":
                 issues.append(f"{name}: {status.get('warning', 'Attention')}")
         
         # Génération recommandations
@@ -136,12 +137,7 @@ class DiagnosticManager:
         )
         
         # Détermination statut global
-        if any(s.get("status") == "error" for _, s in all_checks):
-            overall = "critical"
-        elif any(s.get("status") == "warning" for _, s in all_checks):
-            overall = "warning"
-        else:
-            overall = "healthy"
+        overall = self._compute_overall_status([s for _, s in all_checks])
         
         return HealthStatus(
             timestamp=datetime.now(timezone.utc),
@@ -155,6 +151,29 @@ class DiagnosticManager:
             issues=issues,
             recommendations=recommendations
         )
+
+    @staticmethod
+    def _normalize_check_status(status: Optional[str]) -> str:
+        """
+        Harmonise les statuts des checks vers:
+        - "ok"
+        - "warning"
+        - "critical"
+        """
+        if status in {"error", "critical"}:
+            return "critical"
+        if status == "warning":
+            return "warning"
+        return "ok"
+
+    def _compute_overall_status(self, statuses: List[Dict[str, Any]]) -> str:
+        """Détermine le statut global en harmonisant les statuts des checks."""
+        normalized = [self._normalize_check_status(s.get("status")) for s in statuses]
+        if "critical" in normalized:
+            return "critical"
+        if "warning" in normalized:
+            return "warning"
+        return "healthy"
     
     async def _check_docker(self) -> Dict[str, Any]:
         """Vérifie l'état Docker."""

--- a/tests/test_diagnostic_manager.py
+++ b/tests/test_diagnostic_manager.py
@@ -1,0 +1,103 @@
+import pytest
+
+from autobot.v2.diagnostic_manager import DiagnosticManager
+
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.asyncio
+async def test_run_full_check_overall_is_critical_when_any_check_is_error(monkeypatch):
+    diag = DiagnosticManager()
+
+    async def docker_error():
+        return {"status": "error", "error": "Docker down"}
+
+    monkeypatch.setattr(diag, "_check_docker", docker_error)
+    monkeypatch.setattr(diag, "_check_system", lambda: {"status": "ok"})
+
+    async def network_ok():
+        return {"status": "ok"}
+
+    async def kraken_ok():
+        return {"status": "ok"}
+
+    monkeypatch.setattr(diag, "_check_network", network_ok)
+    monkeypatch.setattr(diag, "_check_kraken", kraken_ok)
+    monkeypatch.setattr(diag, "_check_database", lambda: {"status": "ok"})
+    monkeypatch.setattr(diag, "_check_bot", lambda: {"status": "ok"})
+
+    status = await diag.run_full_check()
+
+    assert status.overall == "critical"
+
+
+@pytest.mark.asyncio
+async def test_run_full_check_overall_is_critical_when_any_check_is_critical(monkeypatch):
+    diag = DiagnosticManager()
+
+    async def docker_ok():
+        return {"status": "ok"}
+
+    monkeypatch.setattr(diag, "_check_docker", docker_ok)
+    monkeypatch.setattr(diag, "_check_system", lambda: {"status": "critical", "warning": "RAM critique"})
+
+    async def network_ok():
+        return {"status": "ok"}
+
+    async def kraken_ok():
+        return {"status": "ok"}
+
+    monkeypatch.setattr(diag, "_check_network", network_ok)
+    monkeypatch.setattr(diag, "_check_kraken", kraken_ok)
+    monkeypatch.setattr(diag, "_check_database", lambda: {"status": "ok"})
+    monkeypatch.setattr(diag, "_check_bot", lambda: {"status": "ok"})
+
+    status = await diag.run_full_check()
+
+    assert status.overall == "critical"
+
+
+@pytest.mark.asyncio
+async def test_run_full_check_overall_is_warning_when_no_critical(monkeypatch):
+    diag = DiagnosticManager()
+
+    async def docker_ok():
+        return {"status": "ok"}
+
+    monkeypatch.setattr(diag, "_check_docker", docker_ok)
+    monkeypatch.setattr(diag, "_check_system", lambda: {"status": "warning", "warning": "RAM élevée"})
+
+    async def network_ok():
+        return {"status": "ok"}
+
+    async def kraken_ok():
+        return {"status": "ok"}
+
+    monkeypatch.setattr(diag, "_check_network", network_ok)
+    monkeypatch.setattr(diag, "_check_kraken", kraken_ok)
+    monkeypatch.setattr(diag, "_check_database", lambda: {"status": "ok"})
+    monkeypatch.setattr(diag, "_check_bot", lambda: {"status": "ok"})
+
+    status = await diag.run_full_check()
+
+    assert status.overall == "warning"
+
+
+@pytest.mark.asyncio
+async def test_run_full_check_overall_is_healthy_when_all_ok(monkeypatch):
+    diag = DiagnosticManager()
+
+    async def check_ok_async():
+        return {"status": "ok"}
+
+    monkeypatch.setattr(diag, "_check_docker", check_ok_async)
+    monkeypatch.setattr(diag, "_check_system", lambda: {"status": "ok"})
+    monkeypatch.setattr(diag, "_check_network", check_ok_async)
+    monkeypatch.setattr(diag, "_check_kraken", check_ok_async)
+    monkeypatch.setattr(diag, "_check_database", lambda: {"status": "ok"})
+    monkeypatch.setattr(diag, "_check_bot", lambda: {"status": "ok"})
+
+    status = await diag.run_full_check()
+
+    assert status.overall == "healthy"


### PR DESCRIPTION
### Motivation

- Harmoniser la manière dont les statuts renvoyés par les checks sont interprétés afin d'éviter des incohérences entre `error` et `critical` lors du calcul du statut global.

### Description

- Introduit la méthode `DiagnosticManager._normalize_check_status` qui mappe `error` et `critical` vers `"critical"`, `warning` vers `"warning"` et tout autre valeur vers `"ok"`.
- Remplace la logique d'agrégation ad-hoc par la méthode `DiagnosticManager._compute_overall_status` qui utilise les statuts normalisés pour retourner `"critical"`, `"warning"` ou `"healthy"`.
- La collecte des `issues` utilise désormais le statut normalisé pour décider d'ajouter les messages d'erreur ou d'avertissement.
- Ajout des tests asynchrones dans `tests/test_diagnostic_manager.py` couvrant les cas `error` → `critical`, `critical` explicite, `warning` sans critique et tout `ok`.

### Testing

- Exécution sans initialisation du chemin (`pytest -q tests/test_diagnostic_manager.py`) a échoué en collecte avec `ModuleNotFoundError: No module named 'autobot'` (attendu sans `PYTHONPATH`).
- Tests exécutés avec `PYTHONPATH=src pytest -q tests/test_diagnostic_manager.py` ont réussi: `4 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8f2496ffc832fab413d33f26a7dea)