### PR TITLE
Use non-blocking CPU sampling in dashboard /api/system and add responsiveness test

### DIFF
--- a/src/autobot/v2/api/dashboard.py
+++ b/src/autobot/v2/api/dashboard.py
@@ -1434,7 +1434,7 @@ async def get_system_metrics(authorized: bool = Depends(verify_token)):
         import psutil
         
         # CPU
-        cpu_percent = psutil.cpu_percent(interval=1)
+        cpu_percent = psutil.cpu_percent(interval=None)
         
         # RAM
         mem = psutil.virtual_memory()

--- a/src/autobot/v2/tests/test_dashboard_api_blockers_postmerge.py
+++ b/src/autobot/v2/tests/test_dashboard_api_blockers_postmerge.py
@@ -1,4 +1,6 @@
 import pytest
+import time
+from concurrent.futures import ThreadPoolExecutor
 
 from fastapi.testclient import TestClient
 
@@ -90,3 +92,32 @@ def test_status_total_profit_uses_snapshot_when_status_instances_have_no_profit(
     body = r.json()
     assert body["total_capital"] == 1500.0
     assert body["total_profit"] == 10.5
+
+
+def test_system_metrics_endpoint_stays_responsive_under_parallel_load(monkeypatch):
+    monkeypatch.setenv("DASHBOARD_API_TOKEN", "tok")
+    client = TestClient(dashboard.app)
+
+    import psutil
+
+    observed_intervals = []
+
+    def _fake_cpu_percent(interval=None):
+        observed_intervals.append(interval)
+        if interval not in (None, 0):
+            time.sleep(0.2)
+        return 12.3
+
+    monkeypatch.setattr(psutil, "cpu_percent", _fake_cpu_percent)
+
+    def _call_system():
+        return client.get("/api/system", headers={"Authorization": "Bearer tok"})
+
+    started_at = time.perf_counter()
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        responses = list(pool.map(lambda _: _call_system(), range(8)))
+    elapsed = time.perf_counter() - started_at
+
+    assert all(r.status_code == 200 for r in responses)
+    assert observed_intervals and all(interval is None for interval in observed_intervals)
+    assert elapsed < 0.5


### PR DESCRIPTION
### Motivation
- Éviter que l'endpoint `/api/system` bloque l'événement (ou le thread) pendant ~1s par requête en raison de `psutil.cpu_percent(interval=1)`, ce qui rend l'API non réactive sous charge parallèle.

### Description
- Remplacé `psutil.cpu_percent(interval=1)` par `psutil.cpu_percent(interval=None)` dans `src/autobot/v2/api/dashboard.py` pour utiliser le mode non bloquant.
- Ajouté un test de non-régression `test_system_metrics_endpoint_stays_responsive_under_parallel_load` dans `src/autobot/v2/tests/test_dashboard_api_blockers_postmerge.py` qui simule `psutil.cpu_percent`, exécute plusieurs appels parallèles à `/api/system`, vérifie que `cpu_percent` est appelé avec `interval=None` et que les réponses sont rapides.

### Testing
- Tentative d'exécution de `pytest` sur le module de tests échouée car l'environnement de test ici manque la dépendance `httpx` requise par `fastapi.testclient` (échec de collecte). 
- Exécution d'une validation directe via `PYTHONPATH=src python ...` qui appelle `get_system_metrics` de façon concurrente a confirmé que `psutil.cpu_percent` est appelé avec `interval=None` et que les appels terminent rapidement (succès). 
- Le nouveau test a été ajouté mais n'a pas pu être entièrement exécuté dans cet environnement en raison de la dépendance manquante (`httpx`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8f2466d9c832fbb43f55099c16ca6)