### PR TITLE
Masquer les détails d'erreur du endpoint /api/system

### DIFF
--- a/src/autobot/v2/api/dashboard.py
+++ b/src/autobot/v2/api/dashboard.py
@@ -1470,9 +1470,9 @@ async def get_system_metrics(authorized: bool = Depends(verify_token)):
             },
             "timestamp": datetime.now(timezone.utc).isoformat()
         }
-    except Exception as e:
-        logger.error(f"Erreur lors de la récupération des métriques système: {e}")
-        raise HTTPException(status_code=500, detail=f"Erreur système: {str(e)}")
+    except Exception:
+        logger.exception("Erreur lors de la récupération des métriques système")
+        raise HTTPException(status_code=500, detail="Erreur interne")
 
 class DashboardServer:
     """Serveur Dashboard intégré au bot - CORRECTION: graceful shutdown"""


### PR DESCRIPTION
### Motivation
- Éviter la fuite d'informations internes vers les clients via le endpoint `/api/system` en remplaçant les détails d'exception exposés par un message générique tout en conservant les diagnostics côté serveur.

### Description
- Dans `src/autobot/v2/api/dashboard.py`, la fonction `get_system_metrics` logge désormais l'erreur avec `logger.exception(...)` et renvoie `HTTPException(status_code=500, detail="Erreur interne")` au lieu de retourner `f"Erreur système: {str(e)}"` au client.

### Testing
- Exécution de la vérification de syntaxe `python -m py_compile src/autobot/v2/api/dashboard.py` qui a réussi.
- Aucun autre test automatique n'a été exécuté dans ce changement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8f24390a4832fb6d61b1ba335319c)