### PR TITLE
Ban wildcard imports in v2 — explicit import in module_coordinator and lint test

### DIFF
--- a/src/autobot/v2/module_coordinator.py
+++ b/src/autobot/v2/module_coordinator.py
@@ -11,7 +11,7 @@ from typing import Dict, List
 from urllib.parse import urlparse
 from urllib.request import Request, urlopen
 
-from .config import *  # noqa: F401,F403
+from .config import MAX_BACKOFF_SECONDS
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_no_wildcard_imports_v2.py
+++ b/tests/test_no_wildcard_imports_v2.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_no_wildcard_imports_in_autobot_v2() -> None:
+    base_dir = Path(__file__).resolve().parents[1] / "src" / "autobot" / "v2"
+    offenders: list[str] = []
+
+    for py_file in sorted(base_dir.rglob("*.py")):
+        for lineno, line in enumerate(py_file.read_text(encoding="utf-8").splitlines(), start=1):
+            if " import *" in line:
+                offenders.append(f"{py_file.relative_to(base_dir)}:{lineno}")
+
+    assert not offenders, (
+        "Wildcard imports are forbidden in src/autobot/v2/. "
+        f"Replace with explicit imports: {', '.join(offenders)}"
+    )


### PR DESCRIPTION
### Motivation
- Éviter les `import *` qui cachent les dépendances et gênent l’analyse statique et la maintenance du code dans le package `autobot.v2`.

### Description
- Remplacement de `from .config import *` dans `src/autobot/v2/module_coordinator.py` par `from .config import MAX_BACKOFF_SECONDS` et ajout d’un test unitaires `tests/test_no_wildcard_imports_v2.py` qui scanne récursivement `src/autobot/v2/` et échoue si un `import *` est trouvé.

### Testing
- Exécution de `pytest -q tests/test_no_wildcard_imports_v2.py` qui a réussi avec `1 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8fd2ec918832fb042cfa3899e8892)