### PR TITLE
Stream decision journal parsing and add configurable records cap

### DIFF
--- a/src/autobot/v2/decision_journal.py
+++ b/src/autobot/v2/decision_journal.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 import os
 import threading
+from collections import deque
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional
@@ -117,14 +118,15 @@ def build_rejected_opportunity_report(
     *,
     journal_path: str,
     window_hours: Optional[int] = None,
+    max_records: int = 200,
 ) -> Dict[str, Any]:
     """Aggregate rejected opportunity records by reason and symbol."""
     now = datetime.now(timezone.utc)
     cutoff = None
     if window_hours is not None and int(window_hours) > 0:
         cutoff = now.timestamp() - (int(window_hours) * 3600)
+    records_limit = max(0, int(max_records))
 
-    rows: List[Dict[str, Any]] = []
     path = Path(journal_path)
     if not path.exists():
         return {
@@ -137,46 +139,52 @@ def build_rejected_opportunity_report(
             "records": [],
         }
 
-    for line in path.read_text(encoding="utf-8", errors="ignore").splitlines():
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            rec = json.loads(line)
-        except Exception:
-            continue
-        if rec.get("decision_type") != "rejected_opportunity":
-            continue
-        ts = str(rec.get("timestamp") or "")
-        include = True
-        if cutoff is not None and ts:
-            try:
-                dts = datetime.fromisoformat(ts.replace("Z", "+00:00"))
-                include = dts.timestamp() >= cutoff
-            except Exception:
-                include = True
-        if include:
-            rows.append(rec)
-
     by_reason: Dict[str, int] = {}
     by_symbol: Dict[str, int] = {}
     reason_symbol: Dict[str, int] = {}
-    for rec in rows:
-        reasons = rec.get("reasons") or []
-        reason = str(reasons[0]) if reasons else "unknown"
-        symbols = rec.get("symbols") or []
-        symbol = str(symbols[0]) if symbols else "UNKNOWN"
-        by_reason[reason] = by_reason.get(reason, 0) + 1
-        by_symbol[symbol] = by_symbol.get(symbol, 0) + 1
-        key = f"{reason}::{symbol}"
-        reason_symbol[key] = reason_symbol.get(key, 0) + 1
+    total_rejections = 0
+    tail_records = deque(maxlen=records_limit if records_limit > 0 else None)
+
+    with open(path, "r", encoding="utf-8", errors="ignore") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+            except Exception:
+                continue
+            if rec.get("decision_type") != "rejected_opportunity":
+                continue
+            ts = str(rec.get("timestamp") or "")
+            include = True
+            if cutoff is not None and ts:
+                try:
+                    dts = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+                    include = dts.timestamp() >= cutoff
+                except Exception:
+                    include = True
+            if not include:
+                continue
+
+            total_rejections += 1
+            reasons = rec.get("reasons") or []
+            reason = str(reasons[0]) if reasons else "unknown"
+            symbols = rec.get("symbols") or []
+            symbol = str(symbols[0]) if symbols else "UNKNOWN"
+            by_reason[reason] = by_reason.get(reason, 0) + 1
+            by_symbol[symbol] = by_symbol.get(symbol, 0) + 1
+            key = f"{reason}::{symbol}"
+            reason_symbol[key] = reason_symbol.get(key, 0) + 1
+            if records_limit > 0:
+                tail_records.append(rec)
 
     return {
         "generated_at": now.isoformat(),
         "window_hours": int(window_hours) if window_hours is not None else None,
-        "total_rejections": len(rows),
+        "total_rejections": total_rejections,
         "by_reason": dict(sorted(by_reason.items(), key=lambda kv: kv[1], reverse=True)),
         "by_symbol": dict(sorted(by_symbol.items(), key=lambda kv: kv[1], reverse=True)),
         "reason_symbol": dict(sorted(reason_symbol.items(), key=lambda kv: kv[1], reverse=True)),
-        "records": rows[-200:],
+        "records": list(tail_records),
     }

--- a/src/autobot/v2/tests/test_rejected_opportunity_analytics.py
+++ b/src/autobot/v2/tests/test_rejected_opportunity_analytics.py
@@ -88,3 +88,27 @@ def test_rejected_opportunity_report_safe_when_sparse_or_absent(tmp_path):
     assert report["by_reason"] == {}
     assert report["by_symbol"] == {}
     assert report["records"] == []
+
+
+def test_rejected_opportunity_report_records_limit_is_configurable(tmp_path):
+    out = tmp_path / "decision_journal.jsonl"
+    journal = DecisionJournal(enabled=True, journal_path=str(out), runtime_context={"paper_trading": True})
+    for idx in range(5):
+        journal.log(
+            decision_type="rejected_opportunity",
+            source="test",
+            symbols=["XXBTZEUR"],
+            reasons=[REJECTION_REASON_VALIDATION_GUARD_BLOCK],
+            context={"idx": idx},
+        )
+    journal.close()
+
+    report = build_rejected_opportunity_report(journal_path=str(out), max_records=2)
+    assert report["total_rejections"] == 5
+    assert len(report["records"]) == 2
+    assert report["records"][0]["context"]["idx"] == 3
+    assert report["records"][1]["context"]["idx"] == 4
+
+    no_record_report = build_rejected_opportunity_report(journal_path=str(out), max_records=0)
+    assert no_record_report["total_rejections"] == 5
+    assert no_record_report["records"] == []


### PR DESCRIPTION
### Motivation
- Avoid loading the entire JSONL decision journal into memory by streaming the file line-by-line in `build_rejected_opportunity_report`.
- Preserve existing aggregations while bounding memory usage outside the returned result and allow operators to limit how many records are returned.

### Description
- Rewrote `build_rejected_opportunity_report` to iterate the journal with `with open(...)` and parse JSONL one line at a time.
- Kept incremental aggregations (`total_rejections`, `by_reason`, `by_symbol`, `reason_symbol`) and updated counts as records are streamed.
- Added a `max_records: int = 200` parameter and used `collections.deque` to retain only the trailing records up to the configured cap, with explicit `max_records=0` handling.
- Added unit test `test_rejected_opportunity_report_records_limit_is_configurable` in `src/autobot/v2/tests/test_rejected_opportunity_analytics.py` to validate the new cap behavior.

### Testing
- Running `pytest -q src/autobot/v2/tests/test_rejected_opportunity_analytics.py` without `PYTHONPATH` failed during collection due to a `ModuleNotFoundError: No module named 'autobot'` (environmental import issue).
- Running `PYTHONPATH=src pytest -q src/autobot/v2/tests/test_rejected_opportunity_analytics.py` succeeded with all tests passing (`4 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8fd311808832f8167b592e67dff3a)