### PR TITLE
Use constant-time comparison for dashboard API token validation

### DIFF
--- a/src/autobot/v2/api/dashboard.py
+++ b/src/autobot/v2/api/dashboard.py
@@ -5,6 +5,7 @@ CORRECTIONS: Auth, thread-safety, graceful shutdown, error handling
 
 import logging
 import os
+import hmac
 import time
 import threading
 import inspect
@@ -82,7 +83,10 @@ def verify_token(credentials: Optional[HTTPAuthorizationCredentials] = Depends(s
             detail="DASHBOARD_API_TOKEN non configuré — accès refusé en production"
         )
 
-    if credentials.credentials.strip() != expected_token.strip():
+    received_token = credentials.credentials.strip()
+    configured_token = expected_token.strip()
+
+    if not hmac.compare_digest(received_token, configured_token):
         logger.warning("Token mismatch from client")
         raise HTTPException(status_code=403, detail="Token invalide")
 


### PR DESCRIPTION
### Motivation
- Éviter les fuites par timing lors de la vérification du token API du dashboard en remplaçant la comparaison de chaînes simple par une comparaison en temps constant.

### Description
- Ajout de l'import `hmac` et remplacement de la comparaison directe par `hmac.compare_digest` dans `verify_token`, en conservant les statuts HTTP existants (401 pour credentials manquants, 500 pour token configuré manquant, 403 pour token invalide).

### Testing
- `python -m py_compile src/autobot/v2/api/dashboard.py` a été exécuté avec succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8fd334860832fa7d25a7adb0a8006)