### PR TITLE
fix(diagnostic): make _check_system CPU sampling non-blocking

### DIFF
--- a/src/autobot/v2/diagnostic_manager.py
+++ b/src/autobot/v2/diagnostic_manager.py
@@ -214,8 +214,8 @@ class DiagnosticManager:
             ram_percent = mem.percent
             ram_available_gb = mem.available / (1024**3)
             
-            # CPU
-            cpu_percent = psutil.cpu_percent(interval=1)
+            # CPU (non bloquant pour éviter de ralentir run_full_check)
+            cpu_percent = psutil.cpu_percent(interval=None)
             
             # Disque
             disk = psutil.disk_usage("/")


### PR DESCRIPTION
### Motivation
- Éviter que `run_full_check` attende ~1s à chaque exécution en raison de l'appel bloquant `psutil.cpu_percent(interval=1)` dans le check système.

### Description
- Remplacement de `psutil.cpu_percent(interval=1)` par `psutil.cpu_percent(interval=None)` dans `src/autobot/v2/diagnostic_manager.py` pour rendre la collecte CPU non bloquante.

### Testing
- Exécution de 10 runs consécutifs de `run_full_check` via un petit script d'import dynamique et mesure des durées, avec min `0.0345 s`, max `0.1478 s` et moyenne `0.0975 s`, le script s'est terminé avec succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8fd34efb0832fb34aaa22e0bb0756)