### PR TITLE
Sécurise les pings de dépendance en épinglant l'IP et en validant l'IP post-connexion

### DIFF
--- a/src/autobot/v2/module_coordinator.py
+++ b/src/autobot/v2/module_coordinator.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 import logging
 import os
 import socket
+import ssl
 import shutil
 from ipaddress import ip_address
 from pathlib import Path
 from time import perf_counter
-from typing import Dict, List
+from typing import Dict, List, Optional
 from urllib.parse import urlparse
-from urllib.request import Request, urlopen
 
 from .config import MAX_BACKOFF_SECONDS
 
@@ -79,6 +79,72 @@ class ModuleCoordinator:
                 return self._reject_ping_url(module, endpoint_name, url, f"forbidden_resolved_ip:{resolved_ip}")
         return True
 
+    def _resolve_allowed_ping_ip(self, hostname: str) -> Optional[str]:
+        try:
+            addr_info = socket.getaddrinfo(hostname, 443, type=socket.SOCK_STREAM)
+        except Exception:
+            return None
+        for addr in addr_info:
+            candidate_ip = addr[4][0]
+            parsed_ip = ip_address(candidate_ip)
+            if parsed_ip.is_private or parsed_ip.is_loopback or parsed_ip.is_link_local:
+                continue
+            return candidate_ip
+        return None
+
+    def _is_allowed_remote_ip(self, ip_value: str) -> bool:
+        try:
+            remote_ip = ip_address(ip_value)
+        except ValueError:
+            return False
+        return not (remote_ip.is_private or remote_ip.is_loopback or remote_ip.is_link_local)
+
+    def _quick_ping_with_pinned_ip(
+        self,
+        hostname: str,
+        request_target: str,
+        timeout: float,
+        port: int = 443,
+    ) -> bool:
+        target_ip = self._resolve_allowed_ping_ip(hostname)
+        if not target_ip:
+            return False
+
+        context = ssl.create_default_context()
+        context.check_hostname = True
+        context.verify_mode = ssl.CERT_REQUIRED
+
+        try:
+            with socket.create_connection((target_ip, port), timeout=timeout) as tcp_sock:
+                with context.wrap_socket(tcp_sock, server_hostname=hostname) as tls_sock:
+                    tls_sock.settimeout(timeout)
+                    remote_peer = tls_sock.getpeername()[0]
+                    if remote_peer != target_ip or not self._is_allowed_remote_ip(remote_peer):
+                        return False
+                    request_data = (
+                        f"HEAD {request_target} HTTP/1.1\r\n"
+                        f"Host: {hostname}\r\n"
+                        "Connection: close\r\n"
+                        "User-Agent: AutobotHealthcheck/1.0\r\n\r\n"
+                    ).encode("ascii", errors="ignore")
+                    tls_sock.sendall(request_data)
+                    first_line = b""
+                    while not first_line.endswith(b"\r\n"):
+                        chunk = tls_sock.recv(1)
+                        if not chunk:
+                            break
+                        first_line += chunk
+
+            if not first_line:
+                return False
+            status_parts = first_line.decode("iso-8859-1", errors="replace").strip().split(" ")
+            if len(status_parts) < 2:
+                return False
+            status_code = int(status_parts[1])
+            return status_code < 500
+        except Exception:
+            return False
+
     def _quick_ping(
         self,
         url: str,
@@ -88,10 +154,20 @@ class ModuleCoordinator:
     ) -> bool:
         if not self._validate_ping_url(url, module=module, endpoint_name=endpoint_name):
             return False
+        parsed = urlparse(url)
+        hostname = (parsed.hostname or "").strip().lower()
+        if not hostname:
+            return False
+        request_target = parsed.path or "/"
+        if parsed.query:
+            request_target = f"{request_target}?{parsed.query}"
         try:
-            req = Request(url, method="HEAD")
-            with urlopen(req, timeout=timeout) as resp:
-                return int(getattr(resp, "status", 200)) < 500
+            return self._quick_ping_with_pinned_ip(
+                hostname=hostname,
+                request_target=request_target,
+                timeout=timeout,
+                port=parsed.port or 443,
+            )
         except Exception:
             return False
 


### PR DESCRIPTION
### Motivation
- Garantir que les vérifications HTTP utilisées pour valider dépendances effectuent une résolution DNS contrôlée et se connectent à une IP autorisée tout en conservant le `Host` header et la vérification TLS (SNI). 

### Description
- Ajout de ` _resolve_allowed_ping_ip` pour résoudre et choisir une adresse IP publique/autorisé à partir d'un hostname et de ` _is_allowed_remote_ip` pour valider une IP distante. 
- Ajout de ` _quick_ping_with_pinned_ip` qui ouvre une connexion TCP vers l'IP épinglée, encapsule en TLS avec `server_hostname` pour SNI, envoie une requête `HEAD` manuelle avec le `Host` attendu et vérifie explicitement que `getpeername()` correspond à l'IP ciblée et reste autorisée. 
- Remplacement du chemin réseau précédent dans ` _quick_ping` pour parser l'URL (hostname/port/path/query) et déléguer vers le nouveau flux épinglé tout en conservant la validation existante dans ` _validate_ping_url`. 
- Ajustements d'import (`ssl`, `Optional`) et suppression de l'utilisation de `urllib.request.urlopen` au profit du flux controlé par IP. 

### Testing
- `python -m py_compile src/autobot/v2/module_coordinator.py` a été exécuté avec succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e90f39be3c832f8adbb0218c39e5bc)