### PR TITLE
Lock AUTOBOT v2 secondary requirements to central lockfiles

### DIFF
--- a/docs/CI_REQUIRED_CHECKS.md
+++ b/docs/CI_REQUIRED_CHECKS.md
@@ -36,3 +36,22 @@ To avoid drift between documentation and CI behavior:
 4. If a required job is moved to another workflow, create a dedicated aggregator in that target workflow and update this file in the same PR.
 
 Additionally, enforce the dedicated pre-merge routine described in `docs/PRE_MERGE_ROUTINE.md`.
+
+## Flux de mise à jour des dépendances secondaires (AUTOBOT V2)
+
+Les fichiers `src/autobot/v2/api/requirements.txt` et `src/autobot/v2/tests/requirements.txt` **ne doivent plus contenir de contraintes flottantes**.
+Ils référencent explicitement les lockfiles centraux:
+
+- `src/autobot/v2/api/requirements.txt` → `requirements/api.txt`
+- `src/autobot/v2/tests/requirements.txt` → `requirements/tests.txt`
+
+Workflow recommandé pour éviter toute divergence de versions:
+
+1. Modifier la source `.in` correspondante uniquement (`requirements/api.in`, `requirements/tests.in`, ou `requirements/runtime.in` selon le besoin).
+2. Régénérer les lockfiles avec `pip-compile` (ou lancer le check automatisé ci-dessous).
+3. Valider localement: `python tools/check_dependency_locks.py`.
+4. Vérifier qu'aucun fichier secondaire sous `src/autobot/v2/**/requirements.txt` n'introduit une version ad hoc (pas de `>=`, `~=` ou version libre).
+5. Committer ensemble: les `.in`, les `.txt` lockés, et la documentation impactée.
+
+Ce flux impose une stratégie **mono-lock** pour les dépendances secondaires V2: la résolution des versions est centralisée dans `requirements/*.txt` et consommée par référence, ce qui aligne dev, CI et production.
+

--- a/src/autobot/v2/api/requirements.txt
+++ b/src/autobot/v2/api/requirements.txt
@@ -1,12 +1,3 @@
 # AUTOBOT V2 - API Requirements
-# Backend FastAPI pour le dashboard
-
-fastapi>=0.104.0
-uvicorn>=0.24.0
-pydantic>=2.5.0
-python-multipart>=0.0.6
-
-# Dépendances déjà présentes dans le projet principal
-# (ne pas dupliquer):
-# - krakenex
-# - websockets
+# Source verrouillée: lock principal du repo (mono-lock)
+-r ../../../../requirements/api.txt

--- a/src/autobot/v2/tests/requirements.txt
+++ b/src/autobot/v2/tests/requirements.txt
@@ -1,6 +1,3 @@
-# AUTOBOT V2 - Tests
-# Dépendances pour les tests API Kraken
-
-krakenex>=1.0.0
-pytest>=7.0.0
-pytest-asyncio>=0.21.0
+# AUTOBOT V2 - Tests Requirements
+# Source verrouillée: lock principal du repo (mono-lock)
+-r ../../../../requirements/tests.txt


### PR DESCRIPTION
### Motivation

- Éviter les contraintes flottantes et la divergence de versions entre les fichiers de dépendances locaux V2 et le lock central en adoptant une stratégie mono-lock.
- Documenter un flux clair de mise à jour pour les dépendances secondaires afin d'aligner dev, CI et production.

### Description

- Remplacement de `src/autobot/v2/api/requirements.txt` par une référence au lock central via `-r ../../../../requirements/api.txt`.
- Remplacement de `src/autobot/v2/tests/requirements.txt` par une référence au lock central via `-r ../../../../requirements/tests.txt`.
- Ajout dans `docs/CI_REQUIRED_CHECKS.md` d'une section `Flux de mise à jour des dépendances secondaires (AUTOBOT V2)` décrivant le workflow recommandé (modifier les `.in`, régénérer avec `pip-compile`, valider avec `python tools/check_dependency_locks.py`, et committer les `.in` + les `.txt` lockés ensemble).

### Testing

- Exécution locale de `python tools/check_dependency_locks.py` qui a échoué dans cet environnement en raison de l'absence du module `piptools` (`No module named piptools`), empêchant la régénération/validation des lockfiles.
- Aucune autre vérification automatisée n'a été exécutée localement; la validation finale des lockfiles sera assurée par la CI (`python-lockfiles` / `python-audit`) lors du pipeline.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e913622624832f8f9eb0607134471d)