### PR TITLE
fix(risk): tolérer la précision flottante dans la validation des paliers

### DIFF
--- a/src/autobot/v2/risk_manager.py
+++ b/src/autobot/v2/risk_manager.py
@@ -81,6 +81,7 @@ class RiskManager:
     
     # Seuil PF global pour disjoncteur
     PF_CIRCUIT_BREAKER_THRESHOLD = 1.2
+    RANGE_CONTINUITY_EPSILON = 1e-9
 
     def __init__(self, configs: Optional[list] = None, orchestrator: Optional[object] = None):
         self.configs = configs or self.DEFAULT_CONFIGS
@@ -96,6 +97,8 @@ class RiskManager:
         if not self.configs:
             raise ValueError("RiskManager requires at least one risk config")
 
+        epsilon = self.RANGE_CONTINUITY_EPSILON
+
         for i, config in enumerate(self.configs):
             if config.capital_min >= config.capital_max:
                 raise ValueError(
@@ -110,9 +113,16 @@ class RiskManager:
             if config.capital_min < prev.capital_min:
                 raise ValueError("Risk config tiers must be sorted by capital_min")
 
-            if config.capital_min != prev.capital_max:
+            boundary_delta = config.capital_min - prev.capital_max
+            if boundary_delta < -epsilon:
                 raise ValueError(
-                    "Risk config tiers must be continuous and non-overlapping: "
+                    "Risk config tiers must be non-overlapping: "
+                    f"previous capital_max={prev.capital_max}, got capital_min={config.capital_min}"
+                )
+
+            if boundary_delta > epsilon:
+                raise ValueError(
+                    "Risk config tiers must be continuous (gap detected): "
                     f"expected capital_min={prev.capital_max}, got {config.capital_min}"
                 )
     


### PR DESCRIPTION
### Motivation
- Éviter les erreurs de validation causées par la précision des floats lorsque les bornes adjacentes sont théoriquement contiguës, tout en conservant le rejet des vrais chevauchements et gaps.

### Description
- Ajout de la constante `RANGE_CONTINUITY_EPSILON = 1e-9` dans `RiskManager`.
- Remplacement de la comparaison d'égalité stricte par le calcul de `boundary_delta = config.capital_min - prev.capital_max` et acceptation des deltas dans `[-epsilon, +epsilon]` comme continuité.
- Conservation des erreurs en cas de vrai chevauchement (`boundary_delta < -epsilon`) ou de vrai gap (`boundary_delta > epsilon`) et clarification des messages d'erreur.

### Testing
- Exécution de `python -m compileall src/autobot/v2/risk_manager.py` qui s'est terminée avec succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e916034ed8832faf21fe2592bc3814)