### PR TITLE
docs: clarify paper attestation requirements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,7 +18,7 @@ API_KEY_ASSIGNED_BOT_ID=bot-paper-01            # obligatoire: doit matcher UNIQ
 MAX_LIVE_INSTANCES=1                            # obligatoire: limite de parallélisme live
 SMALL_LIVE_APPROVED=false                       # optionnelle: gate explicite pour stage small_live
 
-LEAKED_SSH_KEY_ROTATED_ACK=false                # obligatoire sécurité: ack rotation secret compromis
+LEAKED_SSH_KEY_ROTATED_ACK=false                # obligatoire sécurité: passer à true uniquement APRÈS vérification opérationnelle de la rotation des secrets
 SECRET_EXPOSURE_MARKER_PATH=data/compromised_secret.marker  # obligatoire sécurité: arrêt si marker présent
 KRAKEN_API_KEY_FINGERPRINT=                     # optionnelle: empreinte de contrôle clé API
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,48 @@ Valeurs par défaut recommandées: orientées **paper + preflight** (donc pas d'
 
 \* Optionnelles en préflight strict; recommandées pour valider la connectivité exchange.
 
+### Point de sécurité critique: `LEAKED_SSH_KEY_ROTATED_ACK`
+- Cette variable doit rester à `false` tant que la rotation des secrets compromis n'a **pas** été exécutée et vérifiée en conditions opérationnelles.
+- Ne la positionner à `true` qu'après validation explicite (rotation effective + confirmation que les anciens secrets sont invalides).
+
+## Configuration minimale paper qui passe l’attestation
+
+Exemple minimal avec les **valeurs exactes attendues** pour passer l'attestation sécurité en mode paper:
+
+```dotenv
+APP_ENV=production
+DEPLOYMENT_STAGE=paper
+PAPER_TRADING=true
+PREFLIGHT_ONLY=true
+LIVE_TRADING_CONFIRMATION=false
+
+DASHBOARD_API_TOKEN=change_me
+API_KEY_ASSIGNMENT_MODE=dedicated
+ALLOW_SHARED_API_KEY=false
+UNIQUE_BOT_ID=bot-paper-01
+API_KEY_ASSIGNED_BOT_ID=bot-paper-01
+MAX_LIVE_INSTANCES=1
+
+LEAKED_SSH_KEY_ROTATED_ACK=false
+SECRET_EXPOSURE_MARKER_PATH=data/compromised_secret.marker
+
+INITIAL_CAPITAL=1000.0
+MAX_DRAWDOWN_PCT=10
+RISK_PER_TRADE_PCT=1
+MAX_POSITION_SIZE_PCT=20
+
+KRAKEN_API_KEY=
+KRAKEN_API_SECRET=
+```
+
+> Important: `PREFLIGHT_ONLY=true` valide uniquement les garde-fous et checks de sécurité au démarrage. Cela **n'active pas** un trading paper continu.
+
+## Erreurs d’attestation fréquentes
+- `DASHBOARD_API_TOKEN`: absent, vide, ou laissé avec une valeur non conforme à la politique de déploiement.
+- `LEAKED_SSH_KEY_ROTATED_ACK`: mis à `true` sans preuve de rotation opérationnelle des secrets, ou incohérent avec l'état réel de sécurité.
+- Credentials Kraken (`KRAKEN_API_KEY`, `KRAKEN_API_SECRET`): manquants/invalides quand requis par le scénario de validation de connectivité exchange.
+- Rappel: avec `PREFLIGHT_ONLY=true`, l'attestation couvre les checks de sécurité et de configuration, pas l'exécution d'une session paper en continu.
+
 ## Paper-trading operations helpers
 - Validate paper launch config: `python tools/paper_ops.py validate --env-file .env`
 - Print start/run checklist: `python tools/paper_ops.py start-guide`


### PR DESCRIPTION
### Motivation
- Clarifier les exigences de sécurité liées à l'attestation paper, en particulier l'usage de la variable `LEAKED_SSH_KEY_ROTATED_ACK` pour éviter une fausse impression de secrets déjà rotés.
- Fournir une configuration minimale exacte permettant de « passer l’attestation » en mode paper pour réduire les erreurs de déploiement.
- Documenter explicitement que `PREFLIGHT_ONLY=true` n'active pas le trading paper continu et lister les erreurs d'attestation fréquentes bloquantes.

### Description
- Mise à jour de `.env.example` pour préciser que `LEAKED_SSH_KEY_ROTATED_ACK` doit être positionné à `true` uniquement après vérification opérationnelle de la rotation des secrets.
- Ajout dans `README.md` d'une section « Point de sécurité critique: `LEAKED_SSH_KEY_ROTATED_ACK` » expliquant la règle d'usage stricte de cette variable.
- Ajout dans `README.md` d'un bloc `Configuration minimale paper qui passe l’attestation` contenant les valeurs exactes attendues et d'un rappel que `PREFLIGHT_ONLY=true` valide seulement les checks de sécurité.
- Ajout dans `README.md` d'une section `Erreurs d’attestation fréquentes` listant les clés bloquantes (`DASHBOARD_API_TOKEN`, `LEAKED_SSH_KEY_ROTATED_ACK`, `KRAKEN_API_KEY`/`KRAKEN_API_SECRET`).

### Testing
- Vérification du diff avec `git -C /workspace/Projet_AUTOBOT diff -- .env.example README.md` qui a confirmé les modifications attendues (succès).
- Ajout des fichiers et commit avec `git -C /workspace/Projet_AUTOBOT add .env.example README.md` puis `git -C /workspace/Projet_AUTOBOT commit -m "docs: clarify paper attestation requirements"` (commit réussi).
- Inspection des fichiers modifiés avec `nl -ba` pour valider l'insertion des sections dans `README.md` et la modification de `.env.example` (sortie vérifiée avec succès).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e936ee6284832f9aac8162c10cc8bf)