### PR TITLE
Add paper readiness attestation artifact + ops go/no-go workflow

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -21,3 +21,21 @@
 | `exchange_connectivity_timeout` / `api_auth_timeout` / `orders_endpoint_timeout` / `clock_drift_timeout` / `reconciliation_timeout` | Vérifier latence réseau, saturation runtime, ajuster timeouts si nécessaire. |
 | `nonce_io_error` / `db_io_error` / `audit_io_error` / `audit_write_failed` | Vérifier disque/permissions/volume monté, puis valider écriture locale avant relance. |
 | `kill_switch_not_initialized` / `kill_switch_already_tripped` | Réinitialiser proprement le kill switch, investiguer pourquoi il est trippé avant redémarrage live. |
+
+## Go/No-Go paper
+
+Avant toute session paper, générer l’attestation artifact :
+
+```bash
+python tools/paper_ops.py readiness --artifact-file artifacts/startup_attestation.json --format json
+```
+
+Règles de décision à partir de l’artifact JSON (`status`, `reasons`, `diagnostics`) :
+
+- **GO** si `status == "pass"` et `reasons` est vide.
+- **NO-GO** si `status == "fail"` ou si `reasons` contient au moins une raison bloquante.
+- En cas de **NO-GO**, traiter d’abord les entrées de `diagnostics` avec `status="fail"`, corriger la cause, puis relancer la commande `readiness`.
+
+Exploitation pratique:
+- Le script `tools/paper_ops.py readiness` retourne **0** si prêt et **non-zéro** sinon.
+- L’artifact `artifacts/startup_attestation.json` est la source de vérité opérateur pour la décision de lancement.

--- a/src/autobot/v2/startup_attestation.py
+++ b/src/autobot/v2/startup_attestation.py
@@ -53,6 +53,39 @@ class _CheckOutcome:
     error_code: Optional[str] = None
 
 
+
+
+async def write_attestation_artifact(
+    artifact_path: str | Path,
+    *,
+    preflight_only: bool = True,
+    order_executor: Optional[OrderExecutorAsync] = None,
+    kill_switch: Optional[KillSwitch] = None,
+    app_env: Optional[str] = None,
+) -> StartupAttestationResult:
+    gate = StartupAttestation(
+        order_executor=order_executor,
+        kill_switch=kill_switch,
+        app_env=app_env,
+    )
+    result = await gate.run(preflight_only=preflight_only)
+
+    payload = {
+        "status": result.status,
+        "reasons": result.reasons,
+        "diagnostics": result.diagnostics,
+        "ok": result.ok,
+        "checks": result.checks,
+        "preflight_only": preflight_only,
+        "generated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    }
+
+    artifact = Path(artifact_path)
+    artifact.parent.mkdir(parents=True, exist_ok=True)
+    artifact.write_text(json.dumps(payload, indent=2, ensure_ascii=False, sort_keys=True) + "\n", encoding="utf-8")
+    return result
+
+
 class StartupAttestation:
     VALID_ENVS = {"development", "staging", "production"}
     VALID_STAGES = {"paper", "micro_live", "small_live"}
@@ -479,3 +512,32 @@ class StartupAttestation:
                 and max_instances <= 2
             )
         return False
+
+
+def _build_cli_parser() -> "argparse.ArgumentParser":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Generate startup attestation artifact")
+    parser.add_argument("--artifact", default="artifacts/startup_attestation.json", help="path to output JSON artifact")
+    parser.add_argument("--preflight-only", action="store_true", default=False, help="run preflight-only checks")
+    parser.add_argument("--app-env", default=None, help="override APP_ENV value")
+    return parser
+
+
+def _main_cli() -> int:
+    parser = _build_cli_parser()
+    args = parser.parse_args()
+    result = asyncio.run(
+        write_attestation_artifact(
+            artifact_path=args.artifact,
+            preflight_only=bool(args.preflight_only),
+            app_env=args.app_env,
+            kill_switch=KillSwitch(),
+            order_executor=None,
+        )
+    )
+    return 0 if result.ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main_cli())

--- a/src/autobot/v2/tests/test_paper_ops_cli_commands.py
+++ b/src/autobot/v2/tests/test_paper_ops_cli_commands.py
@@ -83,3 +83,26 @@ def test_validate_missing_env_file_exits_nonzero(tmp_path):
 
     assert proc.returncode != 0
     assert "env file not found" in proc.stderr
+
+
+def test_readiness_writes_artifact_and_returns_nonzero_when_not_ready(tmp_path):
+    repo_root = Path(__file__).resolve().parents[4]
+    artifact = tmp_path / "startup_attestation.json"
+
+    proc, payload = _run_json_cli(repo_root, ["readiness", "--artifact-file", str(artifact), "--format", "json"])
+
+    assert proc.returncode != 0
+    assert artifact.exists()
+    assert payload["status"] == "fail"
+    assert isinstance(payload["reasons"], list)
+    assert isinstance(payload["diagnostics"], dict)
+
+
+def test_readiness_json_contains_required_keys(tmp_path):
+    repo_root = Path(__file__).resolve().parents[4]
+    artifact = tmp_path / "attestation_keys.json"
+
+    proc, payload = _run_json_cli(repo_root, ["readiness", "--artifact-file", str(artifact), "--format", "json"])
+
+    assert proc.returncode != 0
+    assert set(["status", "reasons", "diagnostics"]).issubset(payload.keys())

--- a/tests/test_startup_attestation.py
+++ b/tests/test_startup_attestation.py
@@ -2,12 +2,13 @@ import pytest
 
 import asyncio
 import json
+from unittest.mock import AsyncMock
 
 import aiohttp
 
 from autobot.v2.kill_switch import KillSwitch
 from autobot.v2.nonce_manager import NonceManager
-from autobot.v2.startup_attestation import StartupAttestation, _CheckOutcome
+from autobot.v2.startup_attestation import StartupAttestation, _CheckOutcome, write_attestation_artifact
 
 
 pytestmark = pytest.mark.integration
@@ -213,4 +214,57 @@ def test_failure_reason_io_error(monkeypatch, tmp_path):
         assert res.checks["nonce_health"] is False
         assert "nonce_io_error" in res.reasons
         assert res.diagnostics["nonce_health"]["error_code"] == "io"
+    asyncio.run(_run())
+
+
+def test_write_attestation_artifact_format(monkeypatch, tmp_path):
+    async def _run():
+        _base_env(monkeypatch)
+        artifact = tmp_path / "attestation.json"
+        monkeypatch.setattr(StartupAttestation, "_check_exchange_connectivity", AsyncMock(return_value=_CheckOutcome(ok=True, reason="ok", message="exchange ok")))
+        monkeypatch.setattr(StartupAttestation, "_check_api_auth", AsyncMock(return_value=_CheckOutcome(ok=True, reason="ok", message="auth ok")))
+        monkeypatch.setattr(StartupAttestation, "_check_orders_endpoint", AsyncMock(return_value=_CheckOutcome(ok=True, reason="ok", message="orders ok")))
+        monkeypatch.setattr(StartupAttestation, "_check_clock_drift", AsyncMock(return_value=_CheckOutcome(ok=True, reason="ok", message="clock ok")))
+        monkeypatch.setattr(StartupAttestation, "_check_reconciliation_baseline", AsyncMock(return_value=_CheckOutcome(ok=True, reason="ok", message="recon ok")))
+        monkeypatch.setattr(StartupAttestation, "_kill_switch_self_test", AsyncMock(return_value=_CheckOutcome(ok=True, reason="ok", message="ks ok")))
+        result = await write_attestation_artifact(
+            artifact,
+            preflight_only=True,
+            order_executor=DummyExecutor(tmp_path),
+            kill_switch=KillSwitch(),
+        )
+        assert result.ok is True
+        payload = json.loads(artifact.read_text(encoding="utf-8"))
+        assert payload["status"] == "pass"
+        assert isinstance(payload["reasons"], list)
+        assert isinstance(payload["diagnostics"], dict)
+        assert payload["preflight_only"] is True
+        assert "generated_at" in payload
+
+    asyncio.run(_run())
+
+
+def test_write_attestation_artifact_failure_reasons(monkeypatch, tmp_path):
+    async def _run():
+        _base_env(monkeypatch)
+        monkeypatch.setenv("LIVE_TRADING_CONFIRMATION", "false")
+        artifact = tmp_path / "attestation_fail.json"
+        monkeypatch.setattr(StartupAttestation, "_check_exchange_connectivity", AsyncMock(return_value=_CheckOutcome(ok=True, reason="ok", message="exchange ok")))
+        monkeypatch.setattr(StartupAttestation, "_check_api_auth", AsyncMock(return_value=_CheckOutcome(ok=True, reason="ok", message="auth ok")))
+        monkeypatch.setattr(StartupAttestation, "_check_orders_endpoint", AsyncMock(return_value=_CheckOutcome(ok=True, reason="ok", message="orders ok")))
+        monkeypatch.setattr(StartupAttestation, "_check_clock_drift", AsyncMock(return_value=_CheckOutcome(ok=True, reason="ok", message="clock ok")))
+        monkeypatch.setattr(StartupAttestation, "_check_reconciliation_baseline", AsyncMock(return_value=_CheckOutcome(ok=True, reason="ok", message="recon ok")))
+        monkeypatch.setattr(StartupAttestation, "_kill_switch_self_test", AsyncMock(return_value=_CheckOutcome(ok=True, reason="ok", message="ks ok")))
+        result = await write_attestation_artifact(
+            artifact,
+            preflight_only=True,
+            order_executor=DummyExecutor(tmp_path),
+            kill_switch=KillSwitch(),
+        )
+        assert result.ok is False
+        payload = json.loads(artifact.read_text(encoding="utf-8"))
+        assert payload["status"] == "fail"
+        assert "live_confirmation_missing" in payload["reasons"]
+        assert payload["diagnostics"]["live_confirmation"]["status"] == "fail"
+
     asyncio.run(_run())

--- a/tools/paper_ops.py
+++ b/tools/paper_ops.py
@@ -19,6 +19,9 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Tuple
 
+from autobot.v2.kill_switch import KillSwitch
+from autobot.v2.startup_attestation import write_attestation_artifact
+
 TRUE_VALUES = {"1", "true", "yes", "on"}
 
 PAPER_REQUIRED = {
@@ -528,6 +531,28 @@ def cmd_session_summary(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_readiness(args: argparse.Namespace) -> int:
+    result = __import__("asyncio").run(
+        write_attestation_artifact(
+            artifact_path=args.artifact_file,
+            preflight_only=args.preflight_only,
+            kill_switch=KillSwitch(),
+            order_executor=None,
+        )
+    )
+
+    payload = json.loads(Path(args.artifact_file).read_text(encoding="utf-8"))
+    if args.format == "json":
+        print(json.dumps(payload, indent=2, ensure_ascii=False))
+    else:
+        print(f"readiness_status={payload.get('status')} artifact={args.artifact_file}")
+        if payload.get("reasons"):
+            print("reasons=" + ",".join(payload["reasons"]))
+
+    return 0 if result.ok else 1
+
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="AUTOBOT paper operations helper")
     sub = parser.add_subparsers(dest="command", required=True)
@@ -554,6 +579,12 @@ def build_parser() -> argparse.ArgumentParser:
 
     p_flags = sub.add_parser("flags-guide", help="print paper-mode feature flag guidance")
     p_flags.set_defaults(func=lambda _args: (print_flags_guide() or 0))
+
+    p_readiness = sub.add_parser("readiness", help="run startup attestation and write readiness artifact")
+    p_readiness.add_argument("--artifact-file", default="artifacts/startup_attestation.json", help="output JSON artifact path")
+    p_readiness.add_argument("--preflight-only", action="store_true", default=True, help="run preflight-only attestation path")
+    p_readiness.add_argument("--format", choices=("text", "json"), default="text", help="CLI output format")
+    p_readiness.set_defaults(func=cmd_readiness)
 
     return parser
 


### PR DESCRIPTION
### Motivation

- Provide an operator-friendly, machine-readable readiness artifact for paper sessions so operators can decide GO/NO-GO from a single JSON output. 
- Offer a lightweight ops CLI that returns an exit code usable by automation (CI/CD, runbooks) when the bot is not ready.
- Document the operator decision rules in the runbook so launch procedures reference the artifact.
- Add unit tests to assert the artifact format and main failure/exit scenarios.

### Description

- Add `write_attestation_artifact(...)` to `src/autobot/v2/startup_attestation.py` which runs the attestation and writes an artifact JSON containing `status`, `reasons`, `diagnostics`, and metadata (`ok`, `checks`, `preflight_only`, `generated_at`).
- Expose a module-level CLI in `src/autobot/v2/startup_attestation.py` to generate the artifact directly (`--artifact`, `--preflight-only`, `--app-env`).
- Add `readiness` command to `tools/paper_ops.py` that calls `write_attestation_artifact`, prints either text or JSON, writes the artifact (default `artifacts/startup_attestation.json`) and returns `0` when ready and non-zero when not.
- Document a new **Go/No-Go paper** section in `RUNBOOK.md` describing the decision rules based on the artifact fields and showing example usage of `tools/paper_ops.py readiness`.
- Add tests: extend `tests/test_startup_attestation.py` with `test_write_attestation_artifact_format` and `test_write_attestation_artifact_failure_reasons`, and extend `src/autobot/v2/tests/test_paper_ops_cli_commands.py` with tests for the `readiness` command artifact output and exit-code behavior.

### Testing

- Ran targeted tests with `PYTHONPATH=src pytest -q tests/test_startup_attestation.py src/autobot/v2/tests/test_paper_ops_cli_commands.py`, resulting in `18 passed`.
- Verified `tools/paper_ops.py readiness --artifact-file artifacts/startup_attestation.json --format json` generates the artifact and that the CLI exit code reflects `status` (`0` for pass, non-zero for fail) via the added unit tests.
- Existing attestation unit tests were left intact and the new tests assert artifact schema keys and common failure reasons (e.g. `live_confirmation_missing`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e936f0497c832fbce62a28af9341cb)