### PR TITLE
Initialize async signal risk params from env/config with bounds validation

### DIFF
--- a/src/autobot/v2/signal_handler_async.py
+++ b/src/autobot/v2/signal_handler_async.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import time
 import uuid
 import hashlib
@@ -38,11 +39,67 @@ class SignalHandlerAsync:
         self.validator = create_default_validator_engine()
         self._last_signal_time: Optional[datetime] = None
         self._cooldown_seconds = 5
+        self._atr_sl_mult = self._get_positive_float("ATR_SL_MULT", "atr_sl_mult", default=1.8)
+        self._tp_rr = self._get_positive_float("TP_RR", "tp_rr", default=1.6)
+        self._fallback_atr_pct = self._get_positive_float(
+            "FALLBACK_ATR_PCT",
+            "fallback_atr_pct",
+            default=0.01,
+        )
+        self._max_spread_bps = self._get_positive_float("MAX_SPREAD_BPS", "max_spread_bps", default=35.0)
+        self._min_edge_bps = self._get_positive_float("MIN_EDGE_BPS", "min_edge_bps", default=12.0)
+        # Required by sizing/ATR logic in _execute_buy/_estimate_atr_pct.
+        self._risk_per_trade_pct = self._get_positive_float("RISK_PER_TRADE_PCT", "risk_per_trade_pct", default=1.0)
+        self._max_position_capital_pct = self._get_positive_float(
+            "MAX_POSITION_CAPITAL_PCT",
+            "max_position_capital_pct",
+            default=10.0,
+        )
+        self._atr_period = self._get_positive_int("ATR_PERIOD", "atr_period", default=14)
+        self._validate_risk_bounds()
         self._osm = PersistedOrderStateMachine()
         self._kill_switch = KillSwitch(on_trigger=self._on_kill_switch_triggered)
         self._reconciler = StrictReconciliation()
         self._setup_signal_callback()
         logger.info(f"📡 SignalHandlerAsync initialisé pour {instance.id}")
+
+    def _get_positive_float(self, env_name: str, config_attr: str, default: float) -> float:
+        config = getattr(self.instance, "config", None)
+        env_value = os.getenv(env_name)
+        raw = env_value if env_value is not None else getattr(config, config_attr, default)
+        try:
+            value = float(raw)
+        except (TypeError, ValueError):
+            logger.warning("⚠️ %s invalide (%r) -> default %s", env_name, raw, default)
+            return default
+        if value <= 0:
+            logger.warning("⚠️ %s doit être > 0 (reçu=%s) -> default %s", env_name, value, default)
+            return default
+        return value
+
+    def _get_positive_int(self, env_name: str, config_attr: str, default: int) -> int:
+        value = self._get_positive_float(env_name, config_attr, float(default))
+        as_int = int(round(value))
+        if as_int <= 0:
+            logger.warning("⚠️ %s doit être > 0 (reçu=%s) -> default %s", env_name, value, default)
+            return default
+        return as_int
+
+    def _validate_risk_bounds(self) -> None:
+        """Validate cost/risk bounds and enforce coherent bps configuration."""
+        if self._fallback_atr_pct >= 1.0:
+            logger.warning("⚠️ FALLBACK_ATR_PCT=%s trop élevé, clamp à 0.2", self._fallback_atr_pct)
+            self._fallback_atr_pct = 0.2
+        if self._max_spread_bps > 1000.0:
+            logger.warning("⚠️ MAX_SPREAD_BPS=%s incohérent, clamp à 1000", self._max_spread_bps)
+            self._max_spread_bps = 1000.0
+        if self._min_edge_bps >= self._max_spread_bps * 20:
+            logger.warning(
+                "⚠️ MIN_EDGE_BPS=%s incohérent vs MAX_SPREAD_BPS=%s, fallback sur 12 bps",
+                self._min_edge_bps,
+                self._max_spread_bps,
+            )
+            self._min_edge_bps = 12.0
 
     def _setup_signal_callback(self) -> None:
         strategy = getattr(self.instance, "_strategy", None)

--- a/tests/test_signal_handler_async_unit.py
+++ b/tests/test_signal_handler_async_unit.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from autobot.v2.order_executor import OrderResult
+from autobot.v2.signal_handler_async import SignalHandlerAsync
+from autobot.v2.strategies import SignalType, TradingSignal
+
+pytestmark = pytest.mark.unit
+
+
+@dataclass
+class _Cfg:
+    max_positions: int = 5
+
+
+class _Instance:
+    def __init__(self) -> None:
+        self.id = "inst-unit"
+        self.config = _Cfg()
+        self._strategy = None
+        self.status = SimpleNamespace(value="running")
+        self._price_history = []
+        self._persistence = SimpleNamespace(append_audit_event=lambda **_: None)
+
+    def get_available_capital(self):
+        return 1_000.0
+
+    def get_positions_snapshot(self):
+        return []
+
+    async def open_position(self, **_kwargs):
+        return None
+
+
+class _Executor:
+    def __init__(self) -> None:
+        self.market_calls = []
+
+    async def execute_market_order(self, symbol, side, volume):
+        self.market_calls.append((symbol, side.value, volume))
+        return OrderResult(success=True, txid="tx_buy", executed_volume=volume, executed_price=100.0, fees=0.2)
+
+    async def execute_stop_loss_order(self, symbol, side, volume, stop_price):
+        return OrderResult(success=True, txid="tx_sl", executed_volume=volume, executed_price=stop_price)
+
+
+@pytest.mark.asyncio
+async def test_execute_buy_uses_safe_defaults_without_injection(monkeypatch):
+    monkeypatch.delenv("ATR_SL_MULT", raising=False)
+    monkeypatch.delenv("TP_RR", raising=False)
+    monkeypatch.delenv("FALLBACK_ATR_PCT", raising=False)
+    monkeypatch.delenv("MAX_SPREAD_BPS", raising=False)
+    monkeypatch.delenv("MIN_EDGE_BPS", raising=False)
+
+    instance = _Instance()
+    executor = _Executor()
+    handler = SignalHandlerAsync(instance=instance, order_executor=executor)
+
+    signal = TradingSignal(
+        type=SignalType.BUY,
+        symbol="BTC/EUR",
+        price=100.0,
+        volume=0.0,
+        reason="unit-buy",
+        timestamp=datetime.now(timezone.utc),
+        metadata={"spread_bps": 5.0, "expected_move_bps": 80.0, "fee_bps": 20.0, "slippage_bps": 6.0},
+    )
+
+    await handler._execute_buy(signal)
+
+    assert executor.market_calls, "_execute_buy should place a market order with internal defaults"
+
+
+def test_passes_cost_guard_works_with_env_and_bounds(monkeypatch):
+    monkeypatch.setenv("MAX_SPREAD_BPS", "40")
+    monkeypatch.setenv("MIN_EDGE_BPS", "10")
+    monkeypatch.setenv("TP_RR", "1.7")
+
+    handler = SignalHandlerAsync(instance=_Instance(), order_executor=None)
+
+    ok_signal = TradingSignal(
+        type=SignalType.BUY,
+        symbol="BTC/EUR",
+        price=100.0,
+        volume=0.0,
+        reason="ok",
+        timestamp=datetime.now(timezone.utc),
+        metadata={"spread_bps": 8.0, "expected_move_bps": 95.0, "fee_bps": 25.0, "slippage_bps": 6.0},
+    )
+    bad_signal = TradingSignal(
+        type=SignalType.BUY,
+        symbol="BTC/EUR",
+        price=100.0,
+        volume=0.0,
+        reason="bad",
+        timestamp=datetime.now(timezone.utc),
+        metadata={"spread_bps": 55.0, "expected_move_bps": 70.0, "fee_bps": 25.0, "slippage_bps": 10.0},
+    )
+
+    assert handler._passes_cost_guard(ok_signal, atr_pct=0.01) is True
+    assert handler._passes_cost_guard(bad_signal, atr_pct=0.01) is False


### PR DESCRIPTION
### Motivation
- Prevent runtime errors and misconfiguration by ensuring risk/cost parameters used by `_execute_buy` and ATR logic are always initialized and sane.
- Allow `_execute_buy` and `_passes_cost_guard` to be exercised in unit tests without external injection of internal attributes.

### Description
- Initialize `_atr_sl_mult`, `_tp_rr`, `_fallback_atr_pct`, `_max_spread_bps`, and `_min_edge_bps` in `SignalHandlerAsync.__init__` with an `env -> config -> default` priority and safe defaults via `_get_positive_float`/`_get_positive_int`.
- Add `_risk_per_trade_pct`, `_max_position_capital_pct`, and `_atr_period` initializations so sizing and ATR code paths run without external setup.
- Add helpers `_get_positive_float` and `_get_positive_int` that parse env/config values, enforce positive values, and log warnings on invalid input.
- Add `_validate_risk_bounds` to clamp/coerce implausible settings (e.g. excessive `FALLBACK_ATR_PCT`, extreme `MAX_SPREAD_BPS`, incoherent `MIN_EDGE_BPS`) to safe ranges.
- Add unit tests `tests/test_signal_handler_async_unit.py` that call `_execute_buy` with local dummy instance/executor and exercise `_passes_cost_guard` with environment-driven inputs.

### Testing
- Ran `PYTHONPATH=src pytest -q tests/test_signal_handler_async_unit.py` and the new unit tests passed (`2 passed`).
- Ran `PYTHONPATH=src pytest -q tests/test_pf_phase2.py -k cost_guard_filters_low_edge_signal` to validate existing cost-guard behavior and it passed (`1 passed, 5 deselected`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e93c40e194832fac4bd0ba4f51bfea)