### PR TITLE
SignalHandlerAsync: safe init for risk/cost params and unit tests

### DIFF
--- a/src/autobot/v2/signal_handler_async.py
+++ b/src/autobot/v2/signal_handler_async.py
@@ -8,6 +8,7 @@ Connects strategy signals to async order execution.
 from __future__ import annotations
 
 import asyncio
+import os
 import logging
 import time
 import uuid
@@ -38,11 +39,63 @@ class SignalHandlerAsync:
         self.validator = create_default_validator_engine()
         self._last_signal_time: Optional[datetime] = None
         self._cooldown_seconds = 5
+        self._atr_period = 14
+        self._risk_per_trade_pct = self._load_positive_float(
+            "risk_per_trade_pct",
+            "RISK_PER_TRADE_PCT",
+            1.0,
+        )
+        self._max_position_capital_pct = self._load_positive_float(
+            "max_position_capital_pct",
+            "MAX_POSITION_CAPITAL_PCT",
+            15.0,
+        )
+        self._atr_sl_mult = self._load_positive_float("atr_sl_mult", "ATR_SL_MULT", 1.8)
+        self._tp_rr = self._load_positive_float("tp_rr", "TP_RR", 1.6)
+        self._fallback_atr_pct = self._load_positive_float(
+            "fallback_atr_pct",
+            "FALLBACK_ATR_PCT",
+            0.012,
+        )
+        self._max_spread_bps = self._load_positive_float(
+            "max_spread_bps",
+            "MAX_SPREAD_BPS",
+            35.0,
+        )
+        self._min_edge_bps = self._load_positive_float("min_edge_bps", "MIN_EDGE_BPS", 12.0)
+        self._validate_risk_parameters()
         self._osm = PersistedOrderStateMachine()
         self._kill_switch = KillSwitch(on_trigger=self._on_kill_switch_triggered)
         self._reconciler = StrictReconciliation()
         self._setup_signal_callback()
         logger.info(f"📡 SignalHandlerAsync initialisé pour {instance.id}")
+
+    def _load_positive_float(self, config_key: str, env_key: str, default: float) -> float:
+        """Read config then env value and fallback to default on invalid input."""
+        candidate = getattr(getattr(self.instance, "config", None), config_key, default)
+        env_value = os.getenv(env_key)
+        if env_value is not None and str(env_value).strip() != "":
+            candidate = env_value
+        try:
+            value = float(candidate)
+        except (TypeError, ValueError):
+            logger.warning("Paramètre invalide %s=%r, default=%.6f", env_key, candidate, default)
+            return default
+        if value <= 0:
+            logger.warning("Paramètre hors bornes %s=%.6f (doit être > 0), default=%.6f", env_key, value, default)
+            return default
+        return value
+
+    def _validate_risk_parameters(self) -> None:
+        """Normalize parameters to safe bounds for risk/cost guards."""
+        # Safety ranges
+        self._fallback_atr_pct = min(0.25, max(0.001, self._fallback_atr_pct))
+        self._tp_rr = min(8.0, max(0.5, self._tp_rr))
+        self._atr_sl_mult = min(6.0, max(0.5, self._atr_sl_mult))
+        self._max_spread_bps = min(1000.0, max(1.0, self._max_spread_bps))
+        self._min_edge_bps = min(1000.0, max(1.0, self._min_edge_bps))
+        self._risk_per_trade_pct = min(10.0, max(0.05, self._risk_per_trade_pct))
+        self._max_position_capital_pct = min(100.0, max(1.0, self._max_position_capital_pct))
 
     def _setup_signal_callback(self) -> None:
         strategy = getattr(self.instance, "_strategy", None)

--- a/tests/test_signal_handler_async_unit.py
+++ b/tests/test_signal_handler_async_unit.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from autobot.v2.order_executor import OrderResult
+from autobot.v2.signal_handler_async import SignalHandlerAsync
+from autobot.v2.strategies import SignalType, TradingSignal
+from autobot.v2.validator import ValidationStatus
+
+
+pytestmark = pytest.mark.unit
+
+
+@dataclass
+class _Config:
+    max_positions: int = 5
+    atr_sl_mult: float = 2.2
+    tp_rr: float = 1.9
+    fallback_atr_pct: float = 0.02
+    max_spread_bps: float = 25.0
+    min_edge_bps: float = 9.0
+    risk_per_trade_pct: float = 1.5
+    max_position_capital_pct: float = 20.0
+
+
+class _Instance:
+    def __init__(self):
+        self.id = "inst-unit"
+        self.config = _Config()
+        self.status = SimpleNamespace(value="running")
+        self._strategy = None
+        self._price_history = []
+        self._last_price = 100.0
+        self._persistence = SimpleNamespace(append_audit_event=lambda **_: None)
+        self.opened = []
+
+    def get_available_capital(self):
+        return 1_000.0
+
+    def get_positions_snapshot(self):
+        return []
+
+    async def open_position(self, **kwargs):
+        self.opened.append(kwargs)
+        return SimpleNamespace(id="pos-1")
+
+    def get_current_capital(self):
+        return 1_000.0
+
+    def get_profit(self):
+        return 0.0
+
+    async def emergency_stop(self):
+        return None
+
+
+class _Validator:
+    def validate(self, *_args, **_kwargs):
+        return SimpleNamespace(status=ValidationStatus.GREEN, message="ok")
+
+
+class _OSM:
+    def is_duplicate_active(self, *_args, **_kwargs):
+        return False
+
+    def new_order(self, **_kwargs):
+        return SimpleNamespace(client_order_id="cid-1")
+
+    def transition(self, *_args, **_kwargs):
+        return None
+
+
+class _Executor:
+    async def execute_market_order(self, *_args, **_kwargs):
+        return OrderResult(success=True, txid="buy-1", executed_volume=0.2, executed_price=100.0)
+
+    async def execute_stop_loss_order(self, *_args, **_kwargs):
+        return OrderResult(success=True, txid="sl-1")
+
+
+@pytest.mark.asyncio
+async def test_execute_buy_and_cost_guard_without_external_injection():
+    handler = SignalHandlerAsync(instance=_Instance(), order_executor=_Executor())
+    handler.validator = _Validator()
+    handler._osm = _OSM()
+    handler._post_trade_reconcile = _noop_reconcile
+
+    signal = TradingSignal(
+        type=SignalType.BUY,
+        symbol="BTC/EUR",
+        price=100.0,
+        volume=0.2,
+        reason="unit",
+        timestamp=datetime.now(timezone.utc),
+        metadata={"spread_bps": 10.0, "expected_move_bps": 120.0, "fee_bps": 20.0, "slippage_bps": 8.0},
+    )
+
+    assert handler._passes_cost_guard(signal, atr_pct=0.01) is True
+
+    await handler._execute_buy(signal)
+
+    assert len(handler.instance.opened) == 1
+    assert handler.instance.opened[0]["buy_txid"] == "buy-1"
+
+
+def test_init_loads_env_and_clamps_invalid_ranges():
+    import os
+
+    env_backup = {k: os.environ.get(k) for k in ("ATR_SL_MULT", "TP_RR", "FALLBACK_ATR_PCT", "MAX_SPREAD_BPS", "MIN_EDGE_BPS")}
+    try:
+        os.environ["ATR_SL_MULT"] = "-4"  # invalid -> fallback then clamp
+        os.environ["TP_RR"] = "0"  # invalid -> fallback
+        os.environ["FALLBACK_ATR_PCT"] = "10"  # valid but clamped to safe range
+        os.environ["MAX_SPREAD_BPS"] = "0"  # invalid -> fallback
+        os.environ["MIN_EDGE_BPS"] = "20000"  # clamped
+
+        handler = SignalHandlerAsync(instance=_Instance(), order_executor=None)
+
+        assert handler._atr_sl_mult > 0
+        assert handler._tp_rr > 0
+        assert 0.001 <= handler._fallback_atr_pct <= 0.25
+        assert 1.0 <= handler._max_spread_bps <= 1000.0
+        assert 1.0 <= handler._min_edge_bps <= 1000.0
+    finally:
+        for key, value in env_backup.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+async def _noop_reconcile():
+    return None


### PR DESCRIPTION
### Motivation
- Ensure the async signal handler initializes risk and cost-related parameters with safe defaults and supports config/env overrides to avoid dangerous runtime behaviour.
- Validate and clamp bounds for ATR/SL multipliers, R/R, spreads and minimum edge to keep cost-guard calculations coherent.
- Provide small, hermetic unit tests that exercise `_execute_buy` and `_passes_cost_guard` without requiring external services.

### Description
- Added initialization of sizing and cost parameters in `SignalHandlerAsync.__init__` including `_atr_sl_mult`, `_tp_rr`, `_fallback_atr_pct`, `_max_spread_bps`, `_min_edge_bps`, `_risk_per_trade_pct`, `_max_position_capital_pct` and `_atr_period`, reading from instance `config` first then environment variables as overrides (safe defaults provided). 
- Implemented `_load_positive_float(...)` to centralize config/env parsing and positive-value validation with logging on invalid input.
- Implemented `_validate_risk_parameters()` to clamp values into safe ranges (e.g. ATR pct, TP/RR, SL mult, bps, risk sizing) to prevent absurd or unsafe configuration.
- Added unit tests `tests/test_signal_handler_async_unit.py` that use local doubles for `instance`, `validator`, `OSM`, and `executor` and directly call `_passes_cost_guard` and `_execute_buy` to verify behaviour and that env/config loading/clamping works.

### Testing
- Ran `PYTHONPATH=src pytest -q tests/test_signal_handler_async_unit.py` and the suite passed: `2 passed`.
- Tests are unit-scoped (`pytestmark = pytest.mark.unit`) and are self-contained without network or external service dependencies.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e93c40ceec832fa348ed3c2c92dc18)