### PR TITLE
Fee-aware execution: prefer limit post-only, add async limit support and liquidity tracing

### DIFF
--- a/src/autobot/v2/order_executor.py
+++ b/src/autobot/v2/order_executor.py
@@ -38,6 +38,7 @@ class OrderResult:
     executed_volume: float = 0.0
     executed_price: float = 0.0
     fees: float = 0.0
+    liquidity: str = "unknown"  # maker | taker | unknown
     error: Optional[str] = None
     raw_response: Optional[Dict] = None
 

--- a/src/autobot/v2/order_executor_async.py
+++ b/src/autobot/v2/order_executor_async.py
@@ -429,7 +429,66 @@ class OrderExecutorAsync:
         assert txid is not None
         logger.info(f"✅ Ordre accepté, txid: {txid[:8]}...")
 
-        return await self._wait_for_execution(txid, max_wait=60)
+        return await self._wait_for_execution(txid, max_wait=60, fallback_liquidity="taker")
+
+    async def execute_limit_order(
+        self,
+        symbol: str,
+        side: OrderSide,
+        volume: float,
+        limit_price: float,
+        post_only: bool = False,
+        userref: Optional[int] = None,
+    ) -> OrderResult:
+        """Execute a LIMIT order on Kraken (async), optionally post-only."""
+        logger.info(
+            "📤 Ordre LIMIT %s %.6f %s @ %.2f post_only=%s",
+            side.value.upper(),
+            volume,
+            symbol,
+            limit_price,
+            post_only,
+        )
+
+        MIN_VOLUME = 0.0001
+        if volume < MIN_VOLUME:
+            return OrderResult(
+                success=False,
+                error=f"Volume {volume:.6f} inférieur au minimum Kraken ({MIN_VOLUME})",
+            )
+        if volume <= 0:
+            return OrderResult(success=False, error="Volume doit être > 0")
+        if limit_price <= 0:
+            return OrderResult(success=False, error="Prix limite doit être > 0")
+
+        order_params: Dict[str, Any] = {
+            "pair": symbol,
+            "type": side.value,
+            "ordertype": "limit",
+            "price": str(limit_price),
+            "volume": str(volume),
+        }
+        if post_only:
+            order_params["oflags"] = "post"
+        if userref:
+            order_params["userref"] = str(userref)
+
+        success, response = await self._safe_api_call("AddOrder", **order_params)
+        if not success:
+            error_msg = _extract_error(response)
+            logger.error(f"❌ Échec ordre LIMIT: {error_msg}")
+            return OrderResult(success=False, error=error_msg)
+
+        txid, txid_error = _extract_txid(response)
+        if txid_error:
+            return OrderResult(success=False, error=txid_error)
+        assert txid is not None
+        logger.info(f"✅ Ordre LIMIT accepté, txid: {txid[:8]}...")
+        return await self._wait_for_execution(
+            txid,
+            max_wait=60,
+            fallback_liquidity="maker" if post_only else "unknown",
+        )
 
     async def execute_stop_loss_order(
         self,
@@ -477,7 +536,10 @@ class OrderExecutorAsync:
         return OrderResult(success=True, txid=txid)
 
     async def _wait_for_execution(
-        self, txid: str, max_wait: int = 60
+        self,
+        txid: str,
+        max_wait: int = 60,
+        fallback_liquidity: str = "unknown",
     ) -> OrderResult:
         """Wait for order execution and retrieve fill details."""
         deadline = time.monotonic() + max_wait
@@ -499,8 +561,13 @@ class OrderExecutorAsync:
                     info.get("avg_price", 0)
                 )
                 fee = float(info.get("fee", 0))
+                liquidity = str(info.get("liquidity") or fallback_liquidity or "unknown").lower()
                 logger.info(
-                    f"✅ Ordre exécuté: {vol_exec:.6f} @ {avg_price:.2f}€ (frais: {fee:.4f}€)"
+                    "✅ Ordre exécuté: %.6f @ %.2f€ (frais: %.4f€, liquidité: %s)",
+                    vol_exec,
+                    avg_price,
+                    fee,
+                    liquidity,
                 )
                 return OrderResult(
                     success=True,
@@ -508,6 +575,7 @@ class OrderExecutorAsync:
                     executed_volume=vol_exec,
                     executed_price=avg_price,
                     fees=fee,
+                    liquidity=liquidity,
                     raw_response=info,
                 )
 

--- a/src/autobot/v2/order_router.py
+++ b/src/autobot/v2/order_router.py
@@ -679,6 +679,15 @@ class OrderRouter:
                     volume=params["volume"],
                     userref=params.get("userref"),
                 )
+            elif order_type == "limit":
+                return await self._executor.execute_limit_order(
+                    symbol=params["symbol"],
+                    side=OrderSide(params["side"]),
+                    volume=params["volume"],
+                    limit_price=params["price"],
+                    post_only=bool(params.get("post_only", False)),
+                    userref=params.get("userref"),
+                )
             
             elif order_type == "stop_loss":
                 return await self._executor.execute_stop_loss_order(

--- a/src/autobot/v2/persistence.py
+++ b/src/autobot/v2/persistence.py
@@ -492,9 +492,15 @@ class StatePersistence:
                     exchange_order_id TEXT,
                     decision_id TEXT,
                     signal_id TEXT,
+                    execution_liquidity TEXT,
                     created_at TEXT NOT NULL
                 )
             """)
+            # Backward-compatible migration for pre-existing DBs.
+            try:
+                conn.execute("ALTER TABLE trade_ledger ADD COLUMN execution_liquidity TEXT")
+            except sqlite3.OperationalError:
+                pass
 
             # Persisted order lifecycle state machine
             conn.execute("""
@@ -792,6 +798,7 @@ class StatePersistence:
         exchange_order_id: Optional[str] = None,
         decision_id: Optional[str] = None,
         signal_id: Optional[str] = None,
+        execution_liquidity: Optional[str] = None,
         is_opening_leg: bool = False,
         is_closing_leg: bool = False,
     ) -> bool:
@@ -805,8 +812,8 @@ class StatePersistence:
                     INSERT INTO trade_ledger
                     (trade_id, position_id, instance_id, symbol, side, expected_price, executed_price,
                      volume, fees, slippage_bps, realized_pnl, is_opening_leg, is_closing_leg,
-                     exchange_order_id, decision_id, signal_id, created_at)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                     exchange_order_id, decision_id, signal_id, execution_liquidity, created_at)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         trade_id,
@@ -825,6 +832,7 @@ class StatePersistence:
                         exchange_order_id,
                         decision_id,
                         signal_id,
+                        execution_liquidity,
                         now,
                     ),
                 )

--- a/src/autobot/v2/signal_handler_async.py
+++ b/src/autobot/v2/signal_handler_async.py
@@ -23,6 +23,7 @@ from .validator import ValidatorEngine, ValidationStatus, create_default_validat
 from .order_state_machine import PersistedOrderStateMachine
 from .kill_switch import KillSwitch
 from .reconciliation_strict import StrictReconciliation
+from .modules.fee_optimizer import FeeOptimizer
 
 logger = logging.getLogger(__name__)
 
@@ -69,6 +70,7 @@ class SignalHandlerAsync:
         self._kill_switch = KillSwitch(on_trigger=self._on_kill_switch_triggered)
         self._reconciler = StrictReconciliation()
         self._setup_signal_callback()
+        self._fee_optimizer: Optional[FeeOptimizer] = getattr(self.instance, "_fee_optimizer", None)
         logger.info(f"📡 SignalHandlerAsync initialisé pour {instance.id}")
 
     def _load_positive_float(self, config_key: str, env_key: str, default: float) -> float:
@@ -179,19 +181,29 @@ class SignalHandlerAsync:
             return
 
         symbol = self._convert_symbol(signal.symbol)
+        execution_plan = self._build_execution_plan(signal, volume)
         decision_id = f"dec_{uuid.uuid4().hex}"
         signal_id = f"sig_{uuid.uuid4().hex}"
         rec = self._osm.new_order(
             instance_id=self.instance.id,
             symbol=symbol,
             side="buy",
-            order_type="market",
+            order_type=execution_plan["order_type"],
             requested_qty=volume,
             decision_id=decision_id,
             signal_id=signal_id,
         )
         self._osm.transition(rec.client_order_id, "SENT", "submitted_to_exchange")
-        result = await self.order_executor.execute_market_order(symbol, OrderSide.BUY, volume)
+        if execution_plan["order_type"] == "limit":
+            result = await self.order_executor.execute_limit_order(
+                symbol=symbol,
+                side=OrderSide.BUY,
+                volume=volume,
+                limit_price=execution_plan["price"],
+                post_only=bool(execution_plan.get("post_only", False)),
+            )
+        else:
+            result = await self.order_executor.execute_market_order(symbol, OrderSide.BUY, volume)
 
         if not result.success:
             logger.error(f"❌ Échec ordre Kraken: {result.error}")
@@ -210,7 +222,12 @@ class SignalHandlerAsync:
             "ACK",
             "exchange_ack",
             exchange_order_id=result.txid,
-            payload=result.raw_response or {},
+            payload={
+                **(result.raw_response or {}),
+                "liquidity": result.liquidity,
+                "order_type": execution_plan["order_type"],
+                "post_only": bool(execution_plan.get("post_only", False)),
+            },
         )
         if result.executed_volume and result.executed_volume < volume:
             self._osm.transition(
@@ -235,6 +252,20 @@ class SignalHandlerAsync:
 
         executed_price = result.executed_price or signal.price
         executed_volume = result.executed_volume or volume
+        actual_liquidity = self._normalize_liquidity(result.liquidity)
+        logger.info(
+            "💸 Exécution BUY %s: type=%s post_only=%s liquidity=%s reason=%s",
+            symbol,
+            execution_plan["order_type"],
+            bool(execution_plan.get("post_only", False)),
+            actual_liquidity,
+            execution_plan["reason"],
+        )
+        self._record_fee_optimizer_trade(
+            amount=executed_price * executed_volume,
+            fees=result.fees,
+            liquidity=actual_liquidity,
+        )
 
         stop_price, take_profit, trailing_activation, trailing_gap = self._compute_exit_levels(executed_price)
         sl_result = await self.order_executor.execute_stop_loss_order(
@@ -252,6 +283,25 @@ class SignalHandlerAsync:
         )
 
         if position:
+            self.instance._persistence.append_trade_ledger(
+                trade_id=f"trd_{uuid.uuid4().hex}",
+                position_id=position.id,
+                instance_id=self.instance.id,
+                symbol=symbol,
+                side="buy",
+                expected_price=signal.price,
+                executed_price=executed_price,
+                volume=executed_volume,
+                fees=result.fees,
+                slippage_bps=self._slippage_bps(signal.price, executed_price, "buy"),
+                realized_pnl=None,
+                exchange_order_id=result.txid,
+                decision_id=decision_id,
+                signal_id=signal_id,
+                is_opening_leg=True,
+                is_closing_leg=False,
+                execution_liquidity=actual_liquidity,
+            )
             logger.info(f"✅ Position créée: {position.id}")
             # Immutable audit event
             config_hash = hashlib.sha256(
@@ -271,6 +321,7 @@ class SignalHandlerAsync:
                     "max_positions": getattr(self.instance.config, "max_positions", 10),
                 },
                 fees=result.fees,
+                slippage_bps=self._slippage_bps(signal.price, executed_price, "buy"),
                 order_from_status="SENT",
                 order_to_status="FILLED",
                 exchange_raw_normalized=result.raw_response or {},
@@ -305,6 +356,36 @@ class SignalHandlerAsync:
             if result.success:
                 price = result.executed_price or signal.price
                 await self.instance.close_position(pos_id, price, sell_txid=result.txid)
+                actual_liquidity = self._normalize_liquidity(result.liquidity)
+                logger.info(
+                    "💸 Exécution SELL %s: type=market post_only=False liquidity=%s",
+                    symbol,
+                    actual_liquidity,
+                )
+                self._record_fee_optimizer_trade(
+                    amount=price * vol,
+                    fees=result.fees,
+                    liquidity=actual_liquidity,
+                )
+                self.instance._persistence.append_trade_ledger(
+                    trade_id=f"trd_{uuid.uuid4().hex}",
+                    position_id=pos_id,
+                    instance_id=self.instance.id,
+                    symbol=symbol,
+                    side="sell",
+                    expected_price=signal.price,
+                    executed_price=price,
+                    volume=vol,
+                    fees=result.fees,
+                    slippage_bps=self._slippage_bps(signal.price, price, "sell"),
+                    realized_pnl=pos.get("profit"),
+                    exchange_order_id=result.txid,
+                    decision_id=None,
+                    signal_id=None,
+                    is_opening_leg=False,
+                    is_closing_leg=True,
+                    execution_liquidity=actual_liquidity,
+                )
                 if sl_txid:
                     await self.order_executor.cancel_order(sl_txid)
                 await self._post_trade_reconcile()
@@ -470,15 +551,61 @@ class SignalHandlerAsync:
         return float(raw if side == "buy" else -raw)
 
     def _passes_cost_guard(self, signal: TradingSignal, atr_pct: float) -> bool:
-        spread_bps = float(signal.metadata.get("spread_bps", 0.0))
+        metadata = signal.metadata or {}
+        spread_bps = float(metadata.get("spread_bps", 0.0))
         if spread_bps > self._max_spread_bps:
             logger.info("Spread %.1f bps > max %.1f bps", spread_bps, self._max_spread_bps)
             return False
-        expected_move_bps = float(signal.metadata.get("expected_move_bps", atr_pct * 10000 * self._tp_rr))
-        fee_bps = float(signal.metadata.get("fee_bps", 40.0))
-        slippage_bps = float(signal.metadata.get("slippage_bps", max(6.0, spread_bps * 0.35)))
+        expected_move_bps = float(metadata.get("expected_move_bps", atr_pct * 10000 * self._tp_rr))
+        fee_bps = float(metadata.get("fee_bps", 40.0))
+        slippage_bps = float(metadata.get("slippage_bps", max(6.0, spread_bps * 0.35)))
         total_cost_bps = fee_bps + slippage_bps + spread_bps
         return (expected_move_bps - total_cost_bps) >= self._min_edge_bps
+
+    def _build_execution_plan(self, signal: TradingSignal, volume: float) -> dict[str, Any]:
+        metadata = signal.metadata or {}
+        spread_bps = float(metadata.get("spread_bps", 0.0))
+        expected_move_bps = float(metadata.get("expected_move_bps", self._min_edge_bps + spread_bps + 40.0))
+        fee_bps = float(metadata.get("fee_bps", 40.0))
+        slippage_bps = float(metadata.get("slippage_bps", max(6.0, spread_bps * 0.35)))
+        edge_bps = expected_move_bps - (spread_bps + fee_bps + slippage_bps)
+        urgency = max(0.0, min(1.0, float(metadata.get("urgency", 0.0))))
+        low_urgency = urgency <= 0.35
+        has_edge = edge_bps >= self._min_edge_bps
+
+        amount = max(signal.price * volume, 0.0)
+        rec = (
+            self._fee_optimizer.recommend(
+                side="buy",
+                price=signal.price,
+                amount=amount,
+                urgency=urgency,
+                spread_pct=(spread_bps / 100.0),
+            )
+            if self._fee_optimizer is not None
+            else {"order_type": "market", "post_only": False, "reason": "fee_optimizer_unavailable"}
+        )
+        prefer_limit = low_urgency and has_edge and rec.get("order_type") == "limit"
+        if prefer_limit:
+            price = float(metadata.get("limit_price") or signal.price)
+            return {"order_type": "limit", "post_only": True, "price": price, "reason": rec.get("reason", "low_urgency_edge")}
+        return {"order_type": "market", "post_only": False, "price": signal.price, "reason": rec.get("reason", "market_fallback")}
+
+    @staticmethod
+    def _normalize_liquidity(liquidity: Optional[str]) -> str:
+        normalized = str(liquidity or "unknown").lower()
+        if normalized not in {"maker", "taker"}:
+            return "unknown"
+        return normalized
+
+    def _record_fee_optimizer_trade(self, amount: float, fees: float, liquidity: str) -> None:
+        if self._fee_optimizer is None or amount <= 0:
+            return
+        self._fee_optimizer.record_trade(
+            volume=amount,
+            fee=max(0.0, float(fees or 0.0)),
+            was_maker=(liquidity == "maker"),
+        )
 
     def _compute_unrealized_pnl(self) -> Optional[float]:
         last_price = getattr(self.instance, "_last_price", None)

--- a/src/autobot/v2/tests/test_order_router.py
+++ b/src/autobot/v2/tests/test_order_router.py
@@ -61,6 +61,7 @@ async def router():
     # Mocker l'executor
     router._executor = MagicMock()
     router._executor.execute_market_order = AsyncMock()
+    router._executor.execute_limit_order = AsyncMock()
     router._executor.execute_stop_loss_order = AsyncMock()
     router._executor.cancel_order = AsyncMock()
     router._executor.cancel_all_orders = AsyncMock()
@@ -330,6 +331,31 @@ class TestOrderRouterExecution:
         assert result.success
         assert result.txid == "TEST-123"
         running_router._executor.execute_market_order.assert_called_once()
+
+    async def test_submit_limit_post_only_order(self, running_router):
+        """Test la soumission d'un ordre limit post-only."""
+        expected_result = OrderResult(
+            success=True,
+            txid="LMT-123",
+            executed_price=49990.0,
+            executed_volume=0.02,
+            liquidity="maker",
+        )
+        running_router._executor.execute_limit_order.return_value = expected_result
+
+        order = {
+            "type": "limit",
+            "symbol": "XXBTZEUR",
+            "side": "buy",
+            "volume": 0.02,
+            "price": 49990.0,
+            "post_only": True,
+        }
+        result = await running_router.submit(order, OrderPriority.ORDER)
+
+        assert result.success
+        assert result.liquidity == "maker"
+        running_router._executor.execute_limit_order.assert_called_once()
     
     async def test_submit_stop_loss_order(self, running_router):
         """Test la soumission d'un ordre stop-loss."""


### PR DESCRIPTION
### Motivation

- Réduire les coûts trading en utilisant `FeeOptimizer.recommend` pour privilégier `limit + post_only` quand l'urgence est faible et l'edge net est suffisant.  
- Fournir un chemin d'exécution propre pour les ordres limit (avec support `post_only`) dans la pile async.  
- Améliorer la traçabilité des exécutions en enregistrant si un trade a été maker/taker et en remontant cette information dans les logs et le trade ledger.

### Description

- Le handler async (`SignalHandlerAsync`) appelle désormais `FeeOptimizer.recommend` et construit un `execution_plan` qui choisit `limit+post_only` si `urgency` faible et edge suffisant, sinon `market`, puis soumet l'ordre en conséquence.  
- Ajout de `execute_limit_order(...)` dans `OrderExecutorAsync` (gestion `ordertype=limit`, flag `oflags=post` pour post-only) et enrichissement de `_wait_for_execution` pour exposer la liquidité effective (`maker`/`taker`/`unknown`) dans `OrderResult`.  
- `OrderRouter` accepte désormais `type='limit'` et achemine `price` + `post_only` vers l'exécuteur async.  
- Persistence: ajout du champ `execution_liquidity` à la table `trade_ledger` (création + tentative `ALTER TABLE` protégée pour compatibilité descendante) et écriture des legs d'ouverture/fermeture depuis `SignalHandlerAsync` avec fees/slippage/liquidity.  
- Observabilité: `OrderResult` étend avec `liquidity`, payload OSM/logs incluent `order_type`, `post_only` et `liquidity`.  
- Tests: couverture unitaire du routeur mise à jour pour couvrir la soumission `limit post_only` et mocks adaptés.

### Testing

- Lancer les tests du routeur avec `PYTHONPATH=src pytest -q src/autobot/v2/tests/test_order_router.py -q` a réussi (tous les tests du fichier passent).  
- Vérification syntaxique/compilation avec `python -m py_compile` sur les modules modifiés (`signal_handler_async.py`, `order_executor_async.py`, `order_router.py`, `persistence.py`, `order_executor.py`) a réussi sans erreurs.  
- Les nouveaux/ajustés tests unitaires pour `limit post_only` dans `src/autobot/v2/tests/test_order_router.py` sont inclus et passent localement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e93f298274832f85ffa03a7680c6ad)