### PR TITLE
Optimize `/api/trades` pagination with bounded in-memory merge fallback

### DIFF
--- a/src/autobot/v2/api/dashboard.py
+++ b/src/autobot/v2/api/dashboard.py
@@ -965,9 +965,7 @@ async def get_trades(
         raise HTTPException(status_code=503, detail="Orchestrateur non disponible")
 
     try:
-        target_window = offset + limit
-        if target_window <= 0:
-            target_window = limit
+        target_window = max(offset + limit, limit)
 
         total_count = 0
         paginated_trades: List[Dict[str, Any]] = []
@@ -1006,17 +1004,14 @@ async def get_trades(
                         dt = dt.replace(tzinfo=timezone.utc)
                 return dt.timestamp()
 
-            # 1) Collect at most `offset + limit` newest trades per instance.
-            per_instance_top: List[List[Dict[str, Any]]] = []
+            # Fallback strategy: bounded in-memory top-N to avoid full aggregation/sort.
+            # We only retain the `offset + limit` newest trades globally.
+            bounded_heap: List[tuple[float, int, Dict[str, Any]]] = []
+            seq = 0
 
             for inst in instances_data:
                 inst_trades = inst.get("trades_history", [])
                 total_count += len(inst_trades)
-                if not inst_trades:
-                    continue
-
-                bounded_heap: List[tuple[float, int, Dict[str, Any]]] = []
-                seq = 0
                 for trade in inst_trades:
                     ts_value = trade.get("timestamp", default_ts)
                     ts_epoch = _to_epoch(ts_value)
@@ -1040,27 +1035,14 @@ async def get_trades(
                         heapq.heapreplace(bounded_heap, entry)
                     seq += 1
 
-                top_trades = [item[2] for item in sorted(bounded_heap, key=lambda x: (x[0], x[1]), reverse=True)]
-                per_instance_top.append(top_trades)
-
-            # 2) K-way partial merge (descending by timestamp), stop at offset+limit.
-            merge_heap: List[tuple[float, int, int]] = []
-            for idx, trades_list in enumerate(per_instance_top):
-                if trades_list:
-                    heapq.heappush(merge_heap, (-float(trades_list[0]["_ts_epoch"]), idx, 0))
-
-            merged: List[Dict[str, Any]] = []
-            while merge_heap and len(merged) < target_window:
-                _, list_idx, item_idx = heapq.heappop(merge_heap)
-                current = per_instance_top[list_idx][item_idx]
-                merged.append(current)
-
-                next_idx = item_idx + 1
-                if next_idx < len(per_instance_top[list_idx]):
-                    next_item = per_instance_top[list_idx][next_idx]
-                    heapq.heappush(merge_heap, (-float(next_item["_ts_epoch"]), list_idx, next_idx))
-
-            paginated_trades = merged[offset:offset + limit]
+            top_window = [
+                item[2] for item in sorted(
+                    bounded_heap,
+                    key=lambda x: (x[0], x[1]),
+                    reverse=True,
+                )
+            ]
+            paginated_trades = top_window[offset:offset + limit]
             for trade in paginated_trades:
                 trade.pop("_ts_epoch", None)
 

--- a/src/autobot/v2/tests/test_dashboard_api_trades_pagination.py
+++ b/src/autobot/v2/tests/test_dashboard_api_trades_pagination.py
@@ -26,6 +26,32 @@ class _OrchestratorWithPersistence:
         self.persistence = _TradesPersistenceStub()
 
 
+class _OrchestratorWithoutPersistence:
+    persistence = None
+
+    def get_instances_snapshot(self):
+        return [
+            {
+                "id": "inst-1",
+                "name": "Instance 1",
+                "strategy": "grid",
+                "trades_history": [
+                    {"id": "a", "timestamp": "2025-01-01T10:00:00+00:00", "pair": "BTC/EUR"},
+                    {"id": "b", "timestamp": "2025-01-01T12:00:00+00:00", "pair": "ETH/EUR"},
+                ],
+            },
+            {
+                "id": "inst-2",
+                "name": "Instance 2",
+                "strategy": "trend",
+                "trades_history": [
+                    {"id": "c", "timestamp": "2025-01-01T11:00:00+00:00", "pair": "SOL/EUR"},
+                    {"id": "d", "timestamp": "2025-01-01T13:00:00+00:00", "pair": "XRP/EUR"},
+                ],
+            },
+        ]
+
+
 def test_trades_pagination_fields_are_consistent(monkeypatch):
     monkeypatch.setenv("DASHBOARD_API_TOKEN", "tok")
     dashboard.app.state.orchestrator = _OrchestratorWithPersistence()
@@ -42,4 +68,25 @@ def test_trades_pagination_fields_are_consistent(monkeypatch):
         "total": 10,
         "has_more": True,
         "next_offset": 2,
+    }
+
+
+def test_trades_fallback_uses_bounded_top_window(monkeypatch):
+    monkeypatch.setenv("DASHBOARD_API_TOKEN", "tok")
+    dashboard.app.state.orchestrator = _OrchestratorWithoutPersistence()
+    client = TestClient(dashboard.app)
+
+    response = client.get("/api/trades?limit=2&offset=1", headers={"Authorization": "Bearer tok"})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["count"] == 4
+    assert [trade["id"] for trade in payload["trades"]] == ["b", "c"]
+    assert payload["pagination"] == {
+        "limit": 2,
+        "offset": 1,
+        "returned": 2,
+        "total": 4,
+        "has_more": True,
+        "next_offset": 3,
     }


### PR DESCRIPTION
### Motivation
- Avoid unbounded aggregation and full sorting of all instance trade histories in memory for the `/api/trades` endpoint to reduce memory pressure and CPU cost. 
- Preserve the existing response contract (`count`, `pagination`, `trades`) expected by the frontend. 
- Prefer persistence-side pagination when the persistence layer exposes `get_trades_paginated(limit, offset)` to leverage storage-backed queries.

### Description
- Keep using persistence when available by calling `persistence.get_trades_paginated(limit, offset)` and returning its `items` and `total` unchanged. 
- Replace the previous per-instance top-N + K-way merge fallback with a global bounded heap that retains only the newest `offset + limit` trades across all instances, then slice `offset:offset+limit` to build the response. 
- Use `target_window = max(offset + limit, limit)` to avoid accidental zero/negative windows and remove the internal `_ts_epoch` field before returning results. 
- Add a unit test `test_trades_fallback_uses_bounded_top_window` in `src/autobot/v2/tests/test_dashboard_api_trades_pagination.py` that validates ordering and pagination metadata when persistence is not available, while keeping the existing persistence-based pagination test.

### Testing
- Ran `pytest -q src/autobot/v2/tests/test_dashboard_api_trades_pagination.py` which could not complete in this environment due to import resolution (initial run reported `ModuleNotFoundError: No module named 'autobot'` without setting `PYTHONPATH`).
- Ran `PYTHONPATH=src pytest -q src/autobot/v2/tests/test_dashboard_api_trades_pagination.py` which fails here because the test environment is missing `httpx` required by `fastapi.testclient`, so automated tests could not be executed successfully in this CI-like environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e94bb5a020832f95fe5794e5830c47)