### PR TITLE
Impose la référence mono-lock pour les requirements V2 et renforce le check CI

### DIFF
--- a/docs/CI_REQUIRED_CHECKS.md
+++ b/docs/CI_REQUIRED_CHECKS.md
@@ -62,4 +62,7 @@ Workflow recommandé pour éviter toute divergence de versions:
 4. Vérifier qu'aucun fichier secondaire sous `src/autobot/v2/**/requirements.txt` n'introduit une version ad hoc (pas de `>=`, `~=` ou version libre).
 5. Committer ensemble: les `.in`, les `.txt` lockés, et la documentation impactée.
 
+Le contrôle CI `python tools/check_dependency_locks.py` échoue désormais si `src/autobot/v2/api/requirements.txt`
+ou `src/autobot/v2/tests/requirements.txt` contient autre chose qu'une référence `-r` vers le lockfile central attendu.
+
 Ce flux impose une stratégie **mono-lock** pour les dépendances secondaires V2: la résolution des versions est centralisée dans `requirements/*.txt` et consommée par référence, ce qui aligne dev, CI et production.

--- a/src/autobot/v2/api/requirements.txt
+++ b/src/autobot/v2/api/requirements.txt
@@ -1,3 +1,3 @@
-# AUTOBOT V2 - API Requirements
-# Source verrouillée: lock principal du repo (mono-lock)
+# AUTOBOT V2 - API requirements
+# Mono-lock policy: consume only the central locked API dependencies.
 -r ../../../../requirements/api.txt

--- a/src/autobot/v2/tests/requirements.txt
+++ b/src/autobot/v2/tests/requirements.txt
@@ -1,3 +1,3 @@
-# AUTOBOT V2 - Tests Requirements
-# Source verrouillée: lock principal du repo (mono-lock)
+# AUTOBOT V2 - Tests requirements
+# Mono-lock policy: consume only the central locked test dependencies.
 -r ../../../../requirements/tests.txt

--- a/tools/check_dependency_locks.py
+++ b/tools/check_dependency_locks.py
@@ -15,6 +15,11 @@ LOCK_SPECS = [
     (ROOT / "requirements/requirements.in", ROOT / "requirements.txt"),
 ]
 
+SECONDARY_LOCK_REFERENCES = {
+    ROOT / "src/autobot/v2/api/requirements.txt": "-r ../../../../requirements/api.txt",
+    ROOT / "src/autobot/v2/tests/requirements.txt": "-r ../../../../requirements/tests.txt",
+}
+
 
 def _is_pinned_requirement(line: str) -> bool:
     stripped = line.strip()
@@ -35,6 +40,32 @@ def validate_pinning() -> list[str]:
         for lineno, line in enumerate(lockfile.read_text(encoding="utf-8").splitlines(), start=1):
             if not _is_pinned_requirement(line):
                 rel = lockfile.relative_to(ROOT)
+                errors.append(f"Unpinned dependency in {rel}:{lineno} -> {line.strip()}")
+    return errors
+
+
+def validate_secondary_requirements() -> list[str]:
+    errors: list[str] = []
+    for req_file, expected_ref in SECONDARY_LOCK_REFERENCES.items():
+        if not req_file.exists():
+            errors.append(f"Missing requirements file: {req_file.relative_to(ROOT)}")
+            continue
+
+        references = [
+            line.strip()
+            for line in req_file.read_text(encoding="utf-8").splitlines()
+            if line.strip() and not line.strip().startswith("#")
+        ]
+
+        if references != [expected_ref]:
+            rel = req_file.relative_to(ROOT)
+            errors.append(
+                f"{rel} must only reference '{expected_ref}' (found: {references or 'no requirement lines'})"
+            )
+
+        for lineno, line in enumerate(req_file.read_text(encoding="utf-8").splitlines(), start=1):
+            if not _is_pinned_requirement(line):
+                rel = req_file.relative_to(ROOT)
                 errors.append(f"Unpinned dependency in {rel}:{lineno} -> {line.strip()}")
     return errors
 
@@ -72,6 +103,7 @@ def validate_regeneration() -> int:
 
 def main() -> int:
     pin_errors = validate_pinning()
+    pin_errors.extend(validate_secondary_requirements())
     if pin_errors:
         print("\n".join(pin_errors), file=sys.stderr)
         return 1


### PR DESCRIPTION
### Motivation
- Éviter la dérive de versions dans les sous-modules V2 en forçant l'utilisation des lockfiles centraux plutôt que des contraintes flottantes locales.
- Rendre le contrôle CI capable de détecter et d'échouer si des fichiers `src/autobot/v2/**/requirements.txt` introduisent des dépendances non verrouillées ou des références incorrectes.

### Description
- Aligne `src/autobot/v2/api/requirements.txt` et `src/autobot/v2/tests/requirements.txt` pour qu'ils ne contiennent qu'une seule référence `-r` vers `requirements/api.txt` et `requirements/tests.txt` respectivement, avec un commentaire de politique mono-lock.
- Ajoute `SECONDARY_LOCK_REFERENCES` et la fonction `validate_secondary_requirements()` dans `tools/check_dependency_locks.py` pour vérifier que les fichiers V2 ne contiennent que la référence attendue et ne comportent pas de contraintes non pinées.
- Intègre la nouvelle validation dans `main()` afin que l'exécution du check CI échoue quand les fichiers V2 dévient de la politique.
- Met à jour `docs/CI_REQUIRED_CHECKS.md` pour documenter que le contrôle CI échouera si les fichiers V2 ne référencent pas correctement les lockfiles centraux.

### Testing
- Exécution de `python tools/check_dependency_locks.py` (initialement échoué dans l'environnement d'exécution local car `pip-tools` manquait).
- Installation automatisée de `pip-tools` via `python -m pip install pip-tools` pour reproduire l'environnement CI.
- Ré-exécution de `python tools/check_dependency_locks.py` après installation de `pip-tools`, qui a réussi (aucune erreur signalée par la nouvelle validation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e94bb69970832f863019d227d01909)