### PR TITLE
Deterministic validated-IP pinning for ModuleCoordinator quick ping

### DIFF
--- a/src/autobot/v2/module_coordinator.py
+++ b/src/autobot/v2/module_coordinator.py
@@ -63,7 +63,7 @@ class ModuleCoordinator:
         url: str,
         module: str = "dependency",
         endpoint_name: str = "endpoint",
-    ) -> tuple[str, Set[str]] | None:
+    ) -> tuple[str, Set[str], str] | None:
         parsed = urlparse(url)
         if parsed.scheme.lower() != "https":
             self._reject_ping_url(module, endpoint_name, url, "non_https_scheme")
@@ -94,16 +94,20 @@ class ModuleCoordinator:
             return None
 
         allowed_ips: Set[str] = set()
+        selected_ip: str | None = None
         for addr in addr_info:
             resolved_ip = ip_address(addr[4][0])
             if resolved_ip.is_private or resolved_ip.is_loopback or resolved_ip.is_link_local:
                 self._reject_ping_url(module, endpoint_name, url, f"forbidden_resolved_ip:{resolved_ip}")
                 return None
-            allowed_ips.add(str(resolved_ip))
-        if not allowed_ips:
+            resolved_ip_str = str(resolved_ip)
+            allowed_ips.add(resolved_ip_str)
+            if selected_ip is None:
+                selected_ip = resolved_ip_str
+        if not allowed_ips or selected_ip is None:
             self._reject_ping_url(module, endpoint_name, url, "no_valid_resolved_ip")
             return None
-        return hostname, allowed_ips
+        return hostname, allowed_ips, selected_ip
 
     def _resolve_allowed_ping_ip(self, hostname: str) -> Optional[str]:
         try:
@@ -185,12 +189,19 @@ class ModuleCoordinator:
         request_path = parsed.path or "/"
         if parsed.query:
             request_path = f"{request_path}?{parsed.query}"
-        hostname, allowed_ips = resolved
-        target_ip = sorted(allowed_ips)[0]
+        hostname, allowed_ips, target_ip = resolved
         try:
             conn = _PinnedIPHTTPSConnection(host=hostname, target_ip=target_ip, timeout=timeout)
             conn.request("HEAD", request_path, headers={"Host": hostname})
             peer_ip = conn.sock.getpeername()[0] if conn.sock else ""
+            if peer_ip and peer_ip != target_ip:
+                logger.warning(
+                    "Divergence IP/hostname détectée pour _quick_ping (%s): host=%s expected_ip=%s actual_ip=%s",
+                    endpoint_name,
+                    hostname,
+                    target_ip,
+                    peer_ip,
+                )
             if peer_ip not in allowed_ips:
                 self._reject_ping_url(
                     module,

--- a/src/autobot/v2/tests/test_module_coordinator_ping.py
+++ b/src/autobot/v2/tests/test_module_coordinator_ping.py
@@ -1,0 +1,67 @@
+from types import SimpleNamespace
+
+import pytest
+
+from autobot.v2 import module_coordinator as module_coordinator_mod
+from autobot.v2.module_coordinator import ModuleCoordinator
+
+
+pytestmark = pytest.mark.unit
+
+
+def _make_coordinator() -> ModuleCoordinator:
+    orchestrator = SimpleNamespace(
+        _module_backoff={},
+        hardening_flags={},
+        _record_module_event=lambda *_args, **_kwargs: None,
+    )
+    return ModuleCoordinator(orchestrator=orchestrator)
+
+
+def test_quick_ping_uses_validated_ip_without_second_dns_resolution(monkeypatch):
+    coordinator = _make_coordinator()
+    dns_calls = {"count": 0}
+    first_ip = "93.184.216.34"
+    second_ip = "203.0.113.10"
+
+    def fake_getaddrinfo(host, port, type):  # noqa: A002
+        dns_calls["count"] += 1
+        resolved_ip = first_ip if dns_calls["count"] == 1 else second_ip
+        return [(None, None, None, None, (resolved_ip, port))]
+
+    class _FakeSocket:
+        def __init__(self, peer_ip: str) -> None:
+            self._peer_ip = peer_ip
+
+        def getpeername(self):
+            return (self._peer_ip, 443)
+
+    class _FakeResponse:
+        status = 200
+
+    class _FakePinnedConnection:
+        target_ip_seen = None
+
+        def __init__(self, host: str, target_ip: str, timeout: float) -> None:
+            self.host = host
+            self.sock = _FakeSocket(target_ip)
+            self.__class__.target_ip_seen = target_ip
+
+        def request(self, method: str, path: str, headers: dict[str, str]) -> None:
+            assert method == "HEAD"
+            assert headers["Host"] == self.host
+
+        def getresponse(self):
+            return _FakeResponse()
+
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(module_coordinator_mod.socket, "getaddrinfo", fake_getaddrinfo)
+    monkeypatch.setattr(module_coordinator_mod, "_PinnedIPHTTPSConnection", _FakePinnedConnection)
+
+    ok = coordinator._quick_ping("https://api.twitter.com/healthz")
+
+    assert ok is True
+    assert dns_calls["count"] == 1
+    assert _FakePinnedConnection.target_ip_seen == first_ip


### PR DESCRIPTION
### Motivation
- Eviter la re-résolution DNS implicite (TOCTOU) entre la validation et la requête en fixant de manière déterministe l'IP validée lors de la résolution initiale.  
- Conserver le `Host` attendu / SNI pour les requêtes HTTPS tout en garantissant que l'IP utilisée a été précédemment validée.  
- Journaliser toute divergence entre l'IP attendue et l'IP réellement connectée afin de faciliter le diagnostic d'une résolution instable.

### Description
- Faire remonter un `selected_ip` déterministe depuis `_resolve_allowed_ping_ips` en plus du set `allowed_ips` via la signature changée pour retourner `tuple[str, Set[str], str]`.  
- Choisir explicitement la première IP résolue comme `selected_ip` lors de la validation et la réutiliser ensuite sans nouvelle résolution dans `_quick_ping`.  
- Utiliser la connexion pinning existante (`_PinnedIPHTTPSConnection`) avec `target_ip` issu de la validation et conserver `Host`/SNI via l'en-tête `Host`.  
- Ajouter une journalisation `warning` lorsque l'IP du peer après connexion diverge de l'`expected_ip` avant d'appliquer le contrôle allowlist post-connexion.

### Testing
- Ajout d'un test unitaire `src/autobot/v2/tests/test_module_coordinator_ping.py` qui simule une résolution DNS instable et vérifie qu'une seule résolution DNS est effectuée et que la connexion utilise l'IP validée initialement.  
- Exécution du test isolé via `PYTHONPATH=src pytest -q src/autobot/v2/tests/test_module_coordinator_ping.py` réussie (`1 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e94d7b0ad4832fb6573e34f4cba34f)